### PR TITLE
Annotate error types with proper derive

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,7 +84,7 @@ environment:
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
-  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin
   - rustc -vV
   - cargo -vV
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,7 +84,7 @@ environment:
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
-  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin
   - rustc -vV
   - cargo -vV
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ build = "build.rs"
 [dependencies]
 bitflags = "1.1.0"
 cgmath = { version = "0.17.0", features = ["swizzle"] }
+failure = "0.1.5"
 futures-preview = { version = "=0.3.0-alpha.17", features = ["async-await", "nightly"] }
 log = { version = "0.4.7", features = ["std"] }

--- a/src/rhi/rhi_enums.rs
+++ b/src/rhi/rhi_enums.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use failure::Fail;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PhysicalDeviceManufacturer {
@@ -58,65 +59,68 @@ pub enum CommandListLevel {
     Secondary,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum DeviceCreationError {
+    #[fail(display = "Failed to create device.")]
     Failed,
 }
 
 /// A memory-related error
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum MemoryError {
-    /// There's not enough host memory to create the requested object
+    #[fail(display = "There's not enough host memory to create the requested object.")]
     OutOfHostMemory,
 
-    /// There's not enough device memory to create the requested object
+    #[fail(display = "There's not enough device memory to create the requested object.")]
     OutOfDeviceMemory,
 }
 
 /// Errors tha can happen when you try to get a queue from a device
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum QueueGettingError {
-    /// The device does not have enough memory to get you the queue you want
+    #[fail(display = "The device does not have enough memory to get you the queue you want.")]
     OutOfMemory,
 }
 
 /// All the errors you might get when allocating memory
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum AllocationError {
-    /// There's not enough host memory to make the requested allocation
+    #[fail(display = "There's not enough host memory to make the requested allocation")]
     OutOfHostMemory,
 
-    /// There's not enough device memory to make the requested allocation
+    #[fail(display = "There's not enough device memory to make the requested allocation.")]
     OutOfDeviceMemory,
 
-    /// You've made too many memory allocations already
+    #[fail(display = "You've made too many memory allocations already.")]
     TooManyObjects,
 
+    #[fail(display = "Handle Invalid")]
     InvalidExternalHandle,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum DescriptorPoolCreationError {
-    /// There's not enough host memory to create the descriptor pool
+    #[fail(display = "There's not enough host memory to create the descriptor pool.")]
     OutOfHostMemory,
 
-    /// There's not enough device memory to create the descriptor pool
+    #[fail(display = "There's not enough device memory to create the descriptor pool.")]
     OutOfDeviceMemory,
 
-    /// Memory is too fragmented to create the descriptor pool
+    #[fail(display = "Memory is too fragmented to create the descriptor pool.")]
     Fragmentation,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum PipelineCreationError {
-    /// There's not enough host memory to create the pipeline
+    #[fail(display = "There's not enough host memory to create the pipeline.")]
     OutOfHostMemory,
 
-    /// There's not enough device memory to create the pipeline
+    #[fail(display = "There's not enough device memory to create the pipeline.")]
     OutOfDeviceMemory,
 
-    /// One or more shaders failed to compile or link. If debug reports are enabled, details are
-    /// reported through a debug report
+    #[fail(
+        display = "One or more shaders failed to compile or link. If debug reports are enabled, details are reported through a debug report."
+    )]
     InvalidShader,
 }
 


### PR DESCRIPTION
This is a highly boring 2 commit PR. I don't know enough to do high level error stuff in the rhi, so I just annotated things and moved on. If you want to return a result with a failure of arbitrary type (including the standard ones), you should return `Result<_, failure::Error>`. However if you know you are only going to have one error, you should return that instead, as Error it is polymorphic and has a (very very small) runtime cost.