### PR TITLE
[surface] Add surface abstraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod logging;
 pub mod rhi;
 pub mod settings;
 pub mod shaderpack;
+pub mod surface;
 
 #[cfg(test)]
 mod tests {

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -1,0 +1,25 @@
+/// Represents an abstract Surface which provides the objects required for the rendering platform
+pub trait Surface<T, O> {
+    /// Creates or retrieves the object of the type `T` required for the current platform
+    ///
+    /// # Parameters
+    ///
+    /// * `options` - The options passed for retrieving the object
+    fn platform_object(options: O) -> Result<T, SurfaceError>;
+}
+
+/// Errors that can occur during creation/access of the underlying platform object
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
+pub enum SurfaceError {
+    #[fail(display = "Failed to create or access the underlying object")]
+    AccessFailed,
+
+    #[fail(display = "Invalid parameters passed")]
+    InvalidParameters,
+
+    // This is a special case and will usually not occur with the implementations provided
+    // by nova because the generics will prevent this
+    // H
+    #[fail(display = "This Surface can not be used for creating this object")]
+    NotSupported,
+}

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -1,3 +1,5 @@
+use failure::Fail;
+
 /// Represents an abstract Surface which provides the objects required for the rendering platform
 pub trait Surface<T, O> {
     /// Creates or retrieves the object of the type `T` required for the current platform

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -1,27 +1,30 @@
 use failure::Fail;
 
 /// Represents an abstract Surface which provides the objects required for the rendering platform
-pub trait Surface<T, O> {
+///
+/// For windows this would very likely be a `HWND` (window handle), for Vulkan a `SurfaceKHR`.
+/// In the end however it is up to the render engine what it requests, but the 2 shipped with Nova
+/// will require the objects described above
+///
+/// Furthermore do the generic serve as compile time checks. For example, it will prevent that you
+/// can even pass a X11 window to DX12 in the code, as a X11 window won't implement
+/// `Surface<HWND>`
+pub trait Surface<T> {
     /// Creates or retrieves the object of the type `T` required for the current platform
-    ///
-    /// # Parameters
-    ///
-    /// * `options` - The options passed for retrieving the object
-    fn platform_object(options: O) -> Result<T, SurfaceError>;
+    fn platform_object() -> Result<T, SurfaceError>;
 }
 
 /// Errors that can occur during creation/access of the underlying platform object
 #[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum SurfaceError {
     #[fail(display = "Failed to create or access the underlying object")]
-    AccessFailed,
+    CreationOrAccessFailed,
 
-    #[fail(display = "Invalid parameters passed")]
-    InvalidParameters,
+    #[fail(display = "Invalid parameters passed: {}", details)]
+    InvalidParameters { details: String },
 
     // This is a special case and will usually not occur with the implementations provided
-    // by nova because the generics will prevent this
-    // H
+    // by Nova because the generics will prevent this
     #[fail(display = "This Surface can not be used for creating this object")]
     NotSupported,
 }


### PR DESCRIPTION
This adds a very basic abstraction for the surface nova should render to. It basically provides a very abstract trait which allows to create the required object for the rendering platform.

For example, a Windows window would implement `Surface<HWND, ()>` and `Surface<SurfaceKHR, VulkanOptions>`, whereas an X11 window would only implement `Surface<SurfaceKHR, VulkanOption>`. Additionally does this system give users a very simple way to extend the areas nova can render to.