### PR TITLE
Surface improvements

### DIFF
--- a/src/rhi/rhi_traits.rs
+++ b/src/rhi/rhi_traits.rs
@@ -24,7 +24,7 @@ pub trait GraphicsApi {
     fn get_adapters(&self) -> Vec<Self::PhysicalDevice>;
 
     /// Gets the surface this API was created with
-    fn get_surface(&self) -> Rc<Surface<Self::PlatformSurface>>;
+    fn get_surface(&self) -> Rc<dyn Surface<Self::PlatformSurface>>;
 }
 
 /// An implementation of the rendering API. This will probably be a GPU card, but a software

--- a/src/rhi/rhi_traits.rs
+++ b/src/rhi/rhi_traits.rs
@@ -11,14 +11,20 @@ use std::collections::HashMap;
 
 use super::{rhi_enums::*, rhi_structs::*};
 use crate::shaderpack;
+use crate::surface::Surface;
 use cgmath::Vector2;
+use std::rc::Rc;
 
 /// Top-level trait for functions that don't belong to any specific device object
 pub trait GraphicsApi {
     type PhysicalDevice: PhysicalDevice;
+    type PlatformSurface;
 
     /// Gets a list of all available graphics adapters
     fn get_adapters(&self) -> Vec<Self::PhysicalDevice>;
+
+    /// Gets the surface this API was created with
+    fn get_surface(&self) -> Rc<Surface<Self::PlatformSurface>>;
 }
 
 /// An implementation of the rendering API. This will probably be a GPU card, but a software

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -11,7 +11,7 @@ use failure::Fail;
 /// `Surface<HWND>`
 pub trait Surface<T> {
     /// Creates or retrieves the object of the type `T` required for the current platform
-    fn platform_object() -> Result<T, SurfaceError>;
+    fn platform_object(&mut self) -> Result<T, SurfaceError>;
 }
 
 /// Errors that can occur during creation/access of the underlying platform object


### PR DESCRIPTION
This PR improves the surface trait and GraphicsAPI trait. It adds a method to retrieve the Surface back from GraphicsAPI and also makes the `platform_object` function take `&mut self`