### PR TITLE
[rhi] Fix clippy warnings

### DIFF
--- a/src/rhi/rhi_enums.rs
+++ b/src/rhi/rhi_enums.rs
@@ -176,59 +176,59 @@ pub enum BufferUsage {
 
 bitflags! {
     pub struct PipelineStageFlags: u32 {
-        const TOP_OF_PIPE = 0x00000001;
-        const DRAW_INDIRECT = 0x00000002;
-        const VERTEX_INPUT = 0x00000004;
-        const VERTEX_SHADER = 0x00000008;
-        const TESSELLATION_CONTROL_SHADER = 0x00000010;
-        const TESSELLATION_EVALUATION_SHADER = 0x00000020;
-        const GEOMETRY_SHADER = 0x00000040;
-        const FRAGMENT_SHADER = 0x00000080;
-        const EARLY_FRAGMENT_TESTS = 0x00000100;
-        const LATE_FRAGMENT_TESTS = 0x00000200;
-        const COLOR_ATTACHMENT_OUTPUT = 0x00000400;
-        const COMPUTE_SHADER = 0x00000800;
-        const TRANSFER = 0x00001000;
-        const BOTTOM_OF_PIPE = 0x00002000;
-        const HOST = 0x00004000;
-        const ALL_GRAPHICS = 0x00008000;
-        const ALL_COMMANDS = 0x00010000;
-        const SHADING_RATE_IMAGE = 0x00400000;
-        const RAY_TRACING_SHADER = 0x00200000;
-        const ACCELERATION_STRUCTURE_BUILD = 0x02000000;
-        const TASK_SHADER = 0x00080000;
-        const MESH_SHADER = 0x00100000;
-        const FRAGMENT_DENSITY_PROCESS = 0x00800000;
+        const TOP_OF_PIPE = 0x0000_0001;
+        const DRAW_INDIRECT = 0x0000_0002;
+        const VERTEX_INPUT = 0x0000_0004;
+        const VERTEX_SHADER = 0x0000_0008;
+        const TESSELLATION_CONTROL_SHADER = 0x0000_0010;
+        const TESSELLATION_EVALUATION_SHADER = 0x0000_0020;
+        const GEOMETRY_SHADER = 0x0000_0040;
+        const FRAGMENT_SHADER = 0x0000_0080;
+        const EARLY_FRAGMENT_TESTS = 0x0000_0100;
+        const LATE_FRAGMENT_TESTS = 0x0000_0200;
+        const COLOR_ATTACHMENT_OUTPUT = 0x0000_0400;
+        const COMPUTE_SHADER = 0x0000_0800;
+        const TRANSFER = 0x0000_1000;
+        const BOTTOM_OF_PIPE = 0x0000_2000;
+        const HOST = 0x0000_4000;
+        const ALL_GRAPHICS = 0x0000_8000;
+        const ALL_COMMANDS = 0x0001_0000;
+        const SHADING_RATE_IMAGE = 0x0040_0000;
+        const RAY_TRACING_SHADER = 0x0020_0000;
+        const ACCELERATION_STRUCTURE_BUILD = 0x0200_0000;
+        const TASK_SHADER = 0x0008_0000;
+        const MESH_SHADER = 0x0010_0000;
+        const FRAGMENT_DENSITY_PROCESS = 0x0080_0000;
     }
 }
 
 bitflags! {
     pub struct ResourceAccessFlags: u32 {
-        const NO_FLAGS = 0x00000000;
-        const INDEX_READ_BIT = 0x00000002;
-        const VERTEX_ATTRIBUTE_READ_BIT = 0x00000004;
-        const UNIFORM_READ_BIT = 0x00000008;
-        const INPUT_ATTACHMENT_READ_BIT = 0x00000010;
-        const SHADER_READ_BIT = 0x00000020;
-        const SHADER_WRITE_BIT = 0x00000040;
-        const COLOR_ATTACHMENT_READ_BIT = 0x00000080;
-        const COLOR_ATTACHMENT_WRITE_BIT = 0x00000100;
-        const DEPTH_STENCIL_ATTACHMENT_READ_BIT = 0x00000200;
-        const DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = 0x00000400;
-        const TRANSFER_READ_BIT = 0x00000800;
-        const TRANSFER_WRITE_BIT = 0x00001000;
-        const HOST_READ_BIT = 0x00002000;
-        const HOST_WRITE_BIT = 0x00004000;
-        const MEMORY_READ_BIT = 0x00008000;
-        const MEMORY_WRITE_BIT = 0x00010000;
+        const NO_FLAGS = 0x0000_0000;
+        const INDEX_READ_BIT = 0x0000_0002;
+        const VERTEX_ATTRIBUTE_READ_BIT = 0x0000_0004;
+        const UNIFORM_READ_BIT = 0x0000_0008;
+        const INPUT_ATTACHMENT_READ_BIT = 0x0000_0010;
+        const SHADER_READ_BIT = 0x0000_0020;
+        const SHADER_WRITE_BIT = 0x0000_0040;
+        const COLOR_ATTACHMENT_READ_BIT = 0x0000_0080;
+        const COLOR_ATTACHMENT_WRITE_BIT = 0x0000_0100;
+        const DEPTH_STENCIL_ATTACHMENT_READ_BIT = 0x0000_0200;
+        const DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = 0x0000_0400;
+        const TRANSFER_READ_BIT = 0x0000_0800;
+        const TRANSFER_WRITE_BIT = 0x0000_1000;
+        const HOST_READ_BIT = 0x0000_2000;
+        const HOST_WRITE_BIT = 0x0000_4000;
+        const MEMORY_READ_BIT = 0x0000_8000;
+        const MEMORY_WRITE_BIT = 0x0001_0000;
     }
 }
 
 bitflags! {
     pub struct ImageAspectFlags: u32 {
-        const COLOR = 0x00000001;
-        const DEPTH = 0x00000002;
-        const STENCIL = 0x00000004;
+        const COLOR = 0x0000_0001;
+        const DEPTH = 0x0000_0002;
+        const STENCIL = 0x0000_0004;
     }
 }
 

--- a/src/rhi/rhi_traits.rs
+++ b/src/rhi/rhi_traits.rs
@@ -148,7 +148,7 @@ pub trait Device {
     fn create_pipeline_interface(
         &self,
         bindings: &HashMap<String, ResourceBindingDescription>,
-        color_attachments: &Vec<shaderpack::TextureAttachmentInfo>,
+        color_attachments: &[shaderpack::TextureAttachmentInfo],
         depth_texture: &Option<shaderpack::TextureAttachmentInfo>,
     ) -> Result<Self::PipelineInterface, MemoryError>;
 


### PR DESCRIPTION
This fixes all clippy warnings _that aren't already fixed on my branch_.

It's like 2 classes of issue:
- Long numbers should have separators
- Use references to slices instead of references to vectors in an api.
