### PR TITLE
Automatically audit dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: cargo
 install:
   - |
     if ! hash cargo-install-update 2>/dev/null; then
-        cargo install cargo-install-update;
+        cargo install cargo-update;
     fi
   - cargo install-update --allow-no-update cargo-audit cargo-update
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ matrix:
 cache: cargo
 
 install:
+  - cargo install --force cargo-audit
   - |
     if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" == "master" ]]; then
         rustup component add --toolchain $TRAVIS_RUST_VERSION clippy rustfmt;
     fi
 
 script:
+  - cargo audit
   - cargo build --verbose --all --all-targets
   - cargo test --verbose --all --all-targets --no-fail-fast
   - cargo doc --verbose --all --no-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ matrix:
 cache: cargo
 
 install:
-  - cargo install --force cargo-audit
+  - |
+    if ! hash cargo-install-update 2>/dev/null; then
+        cargo install cargo-install-update;
+    fi
+  - cargo install-update --allow-no-update cargo-audit cargo-update
   - |
     if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" == "master" ]]; then
         rustup component add --toolchain $TRAVIS_RUST_VERSION clippy rustfmt;


### PR DESCRIPTION
There is a list of known rust security issues, this checks our dependencies against it and fails if we need to update.

This is a CI only change.