### PR TITLE
Implement Basic Nova Shaderpack Loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "path-dsl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -342,6 +343,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "path-dsl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pin-utils"
@@ -686,6 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum path-dsl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e158ff718e3dd2475cee7701c75a4b6068901f92028e64e11036b9bfdbabeb9b"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "982a35d1194084ba319d65c4a68d24ca28f5fdb5b8bc20899e4eef8641ea5178"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,18 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.33"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,8 +37,8 @@ name = "backtrace-sys"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -51,13 +51,13 @@ name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -121,7 +121,7 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -140,7 +140,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -159,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -216,10 +216,10 @@ name = "futures-select-macro-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ dependencies = [
  "futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -250,11 +250,12 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.6"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -264,20 +265,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -285,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "maplit"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -320,11 +318,11 @@ dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-dsl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -333,7 +331,7 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,7 +339,7 @@ name = "num_cpus"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -361,12 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -383,6 +381,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,21 +397,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -413,10 +427,10 @@ name = "rand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -425,18 +439,17 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -444,20 +457,20 @@ name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -473,7 +486,7 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -489,9 +502,9 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -501,10 +514,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -512,8 +525,8 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -534,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -570,20 +583,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -602,18 +615,23 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "spin"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "syn"
-version = "0.15.42"
+version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -623,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -633,8 +651,18 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -654,12 +682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
-"checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
+"checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "283944cdecc44bf0b8dd010ec9af888d3b4f142844fdbe026c20ef68148d6fe7"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -680,12 +708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-select-macro-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "469d86239defe297ebcaf385ac5e999a77147f2f20eaf2a3aee7bff9e58e20a9"
 "checksum futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4309a25a1069a1f3c10647b227b9afe6722b67a030d3f00a9cbdc171fc038de4"
 "checksum futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "af8198c48b222f02326940ce2b3aa9e6e91a32886eeaad7ca3b8e4c70daa3f4e"
-"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
+"checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
-"checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
-"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
@@ -695,17 +723,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum path-dsl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e158ff718e3dd2475cee7701c75a4b6068901f92028e64e11036b9bfdbabeb9b"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
-"checksum proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "982a35d1194084ba319d65c4a68d24ca28f5fdb5b8bc20899e4eef8641ea5178"
+"checksum proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e688f31d92ffd7c1ddc57a1b4e6d773c0f2a14ee437a4b0a4f5a69c80eb221c8"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
@@ -714,20 +744,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
+"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
-"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
+"checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
+"checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
-"checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
+"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ failure = "0.1.5"
 futures-preview = { version = "=0.3.0-alpha.17", features = ["async-await", "nightly"] }
 log = { version = "0.4.7", features = ["std"] }
 matches = "0.1.8"
+path-dsl = "0.5.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.40"
 

--- a/docs/git.md
+++ b/docs/git.md
@@ -24,7 +24,8 @@ as small in scope as possible.
 * `[docs]` = documentation changes.
 * `[ide]` = changes to accommodate a particular ide
 * `[git]` = git specific changes (.gitignore etc).
-* `[*]` = (fill in * with the name) Nova module `nova-*`. (ex. `nova-shaderpack` would be `[shaderpack]`) 
+* `[*]` = (fill in * with the name) Nova module `nova-*`. (ex. `nova-shaderpack` would be `[shaderpack]`)
+* `[tests]` = testing related changes.
 * `[tools]` = changes to assorted tooling
 
 ## Merge Style

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -123,7 +123,7 @@ where
     P: AsRef<Path>,
 {
     let root = std::fs::canonicalize(root)?;
-    let entry = read_recursive_impl(&root, Path::new("/"))?;
+    let entry = read_recursive_impl(&root, Path::new(""))?;
 
     Ok(DirectoryTree {
         root: std::fs::canonicalize(root)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 #![feature(seek_convenience)]
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
+#![allow(clippy::cognitive_complexity)]
+#![allow(clippy::float_cmp)]
 #![deny(nonstandard_style)]
 #![deny(future_incompatible)]
 #![deny(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(async_closure)]
 #![feature(seek_convenience)]
 #![feature(test)]
+#![feature(type_alias_impl_trait)]
 #![deny(nonstandard_style)]
 #![deny(future_incompatible)]
 #![deny(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,3 @@ pub mod rhi;
 pub mod settings;
 pub mod shaderpack;
 pub mod surface;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/loading/dir/mod.rs
+++ b/src/loading/dir/mod.rs
@@ -79,7 +79,7 @@ impl FileTree for DirectoryFileTree {
     fn read_dir(&self, path: &Path) -> Result<HashSet<PathBuf>, LoadingError> {
         match self.get_node_at_location(path) {
             Some(DirectoryEntry::File) => Err(LoadingError::NotDirectory),
-            Some(DirectoryEntry::Directory { entries: map }) => Ok(map.keys().map(|p| PathBuf::from(p)).collect()),
+            Some(DirectoryEntry::Directory { entries: map }) => Ok(map.keys().map(PathBuf::from).collect()),
             None => Err(LoadingError::PathNotFound),
         }
     }

--- a/src/loading/dir/mod.rs
+++ b/src/loading/dir/mod.rs
@@ -4,7 +4,7 @@ use crate::loading::{FileTree, LoadingError};
 use futures::Future;
 use matches::matches;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 mod iter;
@@ -85,7 +85,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
     }
 
     fn read(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, LoadingError>>>> {
-        let path = path.to_path_buf();
+        let path = path.to_owned();
         let data = self.0.clone();
         Pin::from(Box::new(async move {
             let real_path = {
@@ -96,7 +96,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
             let future = data.reactor.send_async(FileSystemOp::FileRead(real_path));
 
             match future.await {
-                FileSystemOpResult::Error(error) => match error.kind() {
+                FileSystemOpResult::Error(error) => match error.error.kind() {
                     io::ErrorKind::NotFound => Err(LoadingError::PathNotFound),
                     _ => Err(LoadingError::FileSystemError {
                         sub_error: error.into(),
@@ -109,7 +109,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
     }
 
     fn read_u32(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<Vec<u32>, LoadingError>>>> {
-        let path = path.to_path_buf();
+        let path = path.to_owned();
         let data = self.0.clone();
         Pin::from(Box::new(async move {
             let real_path = {
@@ -120,7 +120,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
             let future = data.reactor.send_async(FileSystemOp::FileReadU32(real_path));
 
             match future.await {
-                FileSystemOpResult::Error(error) => match error.kind() {
+                FileSystemOpResult::Error(error) => match error.error.kind() {
                     io::ErrorKind::NotFound => Err(LoadingError::PathNotFound),
                     _ => Err(LoadingError::FileSystemError {
                         sub_error: error.into(),
@@ -133,7 +133,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
     }
 
     fn read_text(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<String, LoadingError>>>> {
-        let path = path.to_path_buf();
+        let path = path.to_owned();
         let data = self.0.clone();
         Pin::from(Box::new(async move {
             let real_path = {
@@ -144,7 +144,7 @@ impl<'a> FileTree<'a> for DirectoryFileTree {
             let future = data.reactor.send_async(FileSystemOp::FileReadText(real_path));
 
             match future.await {
-                FileSystemOpResult::Error(error) => match error.kind() {
+                FileSystemOpResult::Error(error) => match error.error.kind() {
                     io::ErrorKind::NotFound => Err(LoadingError::PathNotFound),
                     _ => Err(LoadingError::FileSystemError {
                         sub_error: error.into(),

--- a/src/loading/dir/reactor.rs
+++ b/src/loading/dir/reactor.rs
@@ -2,7 +2,7 @@ use crate::fs;
 use crate::fs::dir::DirectoryTree;
 use failure::{Backtrace, Fail};
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum FileSystemOp {

--- a/src/loading/dir/reactor.rs
+++ b/src/loading/dir/reactor.rs
@@ -1,8 +1,10 @@
 use crate::fs;
 use crate::fs::dir::DirectoryTree;
+use failure::{Backtrace, Fail};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone)]
 pub enum FileSystemOp {
     RecursiveEnumerate(PathBuf),
     FileRead(PathBuf),
@@ -15,24 +17,43 @@ pub enum FileSystemOpResult {
     FileRead(Vec<u8>),
     FileReadU32(Vec<u32>),
     FileReadText(String),
-    Error(io::Error),
+    Error(FileSystemOpError),
+}
+
+#[derive(Fail, Debug)]
+#[fail(display = "Filesystem error: {:?} on operation {:?}", error, operation)]
+pub struct FileSystemOpError {
+    #[fail(cause)]
+    pub error: io::Error,
+    operation: FileSystemOp,
+    backtrace: Backtrace,
+}
+
+impl FileSystemOpError {
+    fn from_path(error: io::Error, operation: FileSystemOp) -> Self {
+        FileSystemOpError {
+            error,
+            operation,
+            backtrace: Backtrace::new(),
+        }
+    }
 }
 
 /// Core operation of the file system reactor
 pub(in crate::loading::dir) fn file_system_reactor_core(op: FileSystemOp) -> FileSystemOpResult {
-    match op {
-        FileSystemOp::RecursiveEnumerate(path) => match fs::dir::read_recursive(&path) {
+    match &op {
+        FileSystemOp::RecursiveEnumerate(path) => match fs::dir::read_recursive(path) {
             Ok(cache) => FileSystemOpResult::RecursiveEnumerate(cache),
-            Err(err) => FileSystemOpResult::Error(err),
+            Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
         },
         FileSystemOp::FileRead(path) => {
             let file = std::fs::File::open(path);
             match file {
                 Ok(reader) => match fs::file::read_stream_u8(reader) {
                     Ok(result) => FileSystemOpResult::FileRead(result),
-                    Err(err) => FileSystemOpResult::Error(err),
+                    Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
                 },
-                Err(err) => FileSystemOpResult::Error(err),
+                Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
             }
         }
         FileSystemOp::FileReadU32(path) => {
@@ -40,9 +61,9 @@ pub(in crate::loading::dir) fn file_system_reactor_core(op: FileSystemOp) -> Fil
             match file {
                 Ok(reader) => match fs::file::read_stream_u32(reader) {
                     Ok(result) => FileSystemOpResult::FileReadU32(result),
-                    Err(err) => FileSystemOpResult::Error(err),
+                    Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
                 },
-                Err(err) => FileSystemOpResult::Error(err),
+                Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
             }
         }
         FileSystemOp::FileReadText(path) => {
@@ -50,9 +71,9 @@ pub(in crate::loading::dir) fn file_system_reactor_core(op: FileSystemOp) -> Fil
             match file {
                 Ok(reader) => match fs::file::read_stream_string(reader) {
                     Ok(result) => FileSystemOpResult::FileReadText(result),
-                    Err(err) => FileSystemOpResult::Error(err),
+                    Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
                 },
-                Err(err) => FileSystemOpResult::Error(err),
+                Err(err) => FileSystemOpResult::Error(FileSystemOpError::from_path(err, op.clone())),
             }
         }
     }

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -9,6 +9,7 @@
 use failure::{Error, Fail};
 use futures::Future;
 use std::path::Path;
+use std::pin::Pin;
 
 mod dir;
 
@@ -33,24 +34,24 @@ pub trait FileTree<'a> {
     /// Create a file tree from the path provided.
     ///
     /// May be expensive depending on the target you are opening.
-    fn from_path(path: &Path) -> Box<dyn Future<Output = Result<Self::CreateResult, LoadingError>>>;
+    fn from_path(path: &Path) -> Pin<Box<dyn Future<Output = Result<Self::CreateResult, LoadingError>>>>;
 
     /// Checks is file path exists within the current file tree.
-    fn exists(&'a self, path: &Path) -> bool;
+    fn exists(&self, path: &Path) -> bool;
 
     /// Checks if the path points to a file.
     ///
     /// File Exists -> `Ok(true)`
     /// Exists but isn't file -> `Ok(false)`
     /// Path doesn't exist -> [`LoadingError::PathNotFound`]
-    fn is_file(&'a self, path: &Path) -> Result<bool, LoadingError>;
+    fn is_file(&self, path: &Path) -> Result<bool, LoadingError>;
 
     /// Checks if the path points to a directory.
     ///
     /// Directory Exists -> `Ok(true)`
     /// Exists but isn't directory -> `Ok(false)`
     /// Path doesn't exist -> [`LoadingError::PathNotFound`]
-    fn is_dir(&'a self, path: &Path) -> Result<bool, LoadingError>;
+    fn is_dir(&self, path: &Path) -> Result<bool, LoadingError>;
 
     /// Returns an iterator over all paths in the specified directory.
     ///
@@ -60,17 +61,17 @@ pub trait FileTree<'a> {
     /// Reads a file into a vector of u8.
     ///
     /// Fails if file doesn't exist or isn't readable.
-    fn read(&'a self, path: &Path) -> Box<dyn Future<Output = Result<Vec<u8>, LoadingError>>>;
+    fn read(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, LoadingError>>>>;
 
     /// Reads a file as little endian into an array of u32.
     ///
     /// Fails if file doesn't exist or isn't readable.
-    fn read_u32(&'a self, path: &Path) -> Box<dyn Future<Output = Result<Vec<u32>, LoadingError>>>;
+    fn read_u32(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<Vec<u32>, LoadingError>>>>;
 
     /// Reads a file as little endian into an array of u32.
     ///
     /// Fails if file doesn't exist or isn't readable.
-    fn read_text(&'a self, path: &Path) -> Box<dyn Future<Output = Result<String, LoadingError>>>;
+    fn read_text(&self, path: &Path) -> Pin<Box<dyn Future<Output = Result<String, LoadingError>>>>;
 }
 
 /// Error when trying to load a resource.

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -9,7 +9,6 @@
 use failure::{Error, Fail};
 use futures::Future;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 
 mod dir;
 

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -101,9 +101,16 @@ pub async fn load_nova_shaderpack<E>(executor: E, path: PathBuf) -> Result<Shade
 where
     E: SpawnExt + Clone + 'static,
 {
+    // This function is a wrapper which properly dispatches to various sub functions
+
+    // This should actually really be a if let chain, but that's not in the language yet
     match (path.exists(), path.is_dir(), path.extension().and_then(|s| s.to_str())) {
+        // Directory
         (true, true, _) => {
+            // Get the file tree
             let file_tree_res: Result<DirectoryFileTree, _> = DirectoryFileTree::from_path(&path).await;
+
+            // Map error from the LoadingError type to the ShaderpackLoading Failure type
             let file_tree = file_tree_res.map_err(|err| match err {
                 LoadingError::ResourceNotFound => ShaderpackLoadingFailure::PathNotFound(path),
                 LoadingError::FileSystemError { sub_error: e } => {
@@ -111,21 +118,32 @@ where
                 }
                 e => ShaderpackLoadingFailure::UnknownError { sub_error: e.into() },
             })?;
+
+            // Actually load the file path
             load_nova_shaderpack_impl(executor, file_tree).await
         }
+        // Zip File
         (true, false, Some("zip")) => unimplemented!(),
+        // File with unknown extant
         (true, false, Some(ext)) => Err(ShaderpackLoadingFailure::UnsupportedExtension(ext.to_owned())),
+        // File with no extant
         (true, false, None) => Err(ShaderpackLoadingFailure::UnsupportedExtension("<blank>".into())),
+        // Path doesn't exist
         (false, _, _) => Err(ShaderpackLoadingFailure::PathNotFound(path)),
     }
 }
 
+/// Properly handles launching an async task on a executor and
+/// gives back a RemoteHandle.
+///
+/// Will get replaced with a proper async macro
 macro_rules! shaderpack_load_invoke {
     ( into: $typ:ty, $exec:expr, $($args:expr),* ) => {
         $exec.spawn_with_handle(load_json::<$typ, T>($($args),*)).unwrap()
     };
 }
 
+// Will get moved to async helpers
 macro_rules! await_result_vector {
     ($vec:expr ) => {{
         let mut vec = Vec::new();
@@ -137,16 +155,22 @@ macro_rules! await_result_vector {
     }};
 }
 
-// TODO(cwfitzgerald): This code is complicated af, comment it up
 async fn load_nova_shaderpack_impl<E, T>(mut executor: E, tree: T) -> Result<ShaderpackData, ShaderpackLoadingFailure>
 where
     E: SpawnExt + Clone + 'static,
     T: FileTree + Send + Clone + 'static,
 {
+    // To maximize parallelism in an highly async function, you need to dispatch new tasks as soon as you can,
+    // and wait on their results as late as you can. This way you give each async job as much time as possible to
+    // finish, so when you need the result, it is hopefully already ready.
+    //
+    // This can make the code a bit more convoluted, but nothing some good commenting can solve.
+
     // //////////// //
     // Job Creation //
     // //////////// //
 
+    // Dispatch the job to load the "passes.json" file
     let passes_fut = shaderpack_load_invoke!(
         into: Vec<RenderPassCreationInfo>,
         executor,
@@ -154,6 +178,7 @@ where
         "passes.json".into()
     );
 
+    // Dispatch the job to load the "resources.json" file
     let resources_fut = shaderpack_load_invoke!(
         into: ShaderpackResourceData,
         executor,
@@ -161,14 +186,20 @@ where
         "resources.json".into()
     );
 
+    // While those operations are going, get a list of files in the materials folder. Because
+    // of how the loading system work, the file tree is already populated, so this is a fully
+    // synchronous memory operation.
     let materials_folder = enumerate_folder(&tree, "materials")?;
 
+    // We have many files to load, create vectors.
     let mut materials_futs = Vec::new();
     let mut pipelines_futs = Vec::new();
 
+    // Iterate through the materials directory to find the useful files in the files with the needed extant
     for path in materials_folder {
         let full_path = path!("materials" | &path).into();
         let ext = path.extension().and_then(|s| s.to_str());
+        // Match on the extension
         match ext {
             Some("mat") => {
                 let fut = shaderpack_load_invoke!(into: MaterialData, executor, tree.clone(), full_path);
@@ -178,16 +209,20 @@ where
                 let fut = shaderpack_load_invoke!(into: PipelineCreationInfo, executor, tree.clone(), full_path);
                 pipelines_futs.push(fut)
             }
+            // We give no fucks about any other files
             _ => {}
         }
     }
 
+    // We do the same for the shaders folder, but just blanket loading everything
     let shaders_folder: HashSet<PathBuf> = enumerate_folder(&tree, "shaders")?
         .into_iter()
         .map(|path| path!("shaders" | path).into())
         .collect();
 
     let shader_futs: Vec<_> = shaders_folder.iter().map(|p| tree.read_text(p)).collect();
+    // Generate a mapping from path to an index for all shaders
+    // This allows us to load each file only once.
     let shader_mapping: HashMap<&PathBuf, u32> =
         shaders_folder.iter().enumerate().map(|(i, p)| (p, i as u32)).collect();
 
@@ -195,16 +230,22 @@ where
     // Job Resolution //
     // ////////////// //
 
-    let passes = passes_fut.await?;
-    let resources = resources_fut.await?;
+    // Pull all materials files first as we can do something with them
     let mut materials = await_result_vector!(materials_futs);
-    material_postprocess(&mut materials);
+    // We have all the data we need to do the materials postprocess pass
+    set_material_pass_material_name(&mut materials);
+
+    // Pull all pipelines as we also can do stuff with them immediately
     let mut pipelines = await_result_vector!(pipelines_futs);
     pipeline_postprocess(&mut pipelines, shader_mapping);
+
     let shaders = ShaderSet::Sources({
-        let mut vec = Vec::new();
-        vec.reserve(shader_futs.len());
+        let mut vec = Vec::with_capacity(shader_futs.len());
+
+        // Futures are async, but are the actual handles themselves are in the same order
+        // as the filenames, so can be safely zip together
         for (fut, filename) in shader_futs.into_iter().zip(shaders_folder.into_iter()) {
+            // Await the future and translate the error
             let source = fut.await.map_err(|err| match err {
                 LoadingError::NotFile => ShaderpackLoadingFailure::NotFile(filename.clone().into_os_string()),
                 LoadingError::FileSystemError { sub_error } => ShaderpackLoadingFailure::FileSystemError { sub_error },
@@ -216,6 +257,15 @@ where
         vec
     });
 
+    // These weren't actually needed until right now, so there's no point in
+    // awaiting their futures until they are needed.
+
+    // Get the "passes.json" file
+    let passes = passes_fut.await?;
+
+    // Get the "resources.json" file
+    let resources = resources_fut.await?;
+
     Ok(ShaderpackData {
         passes,
         resources,
@@ -225,7 +275,10 @@ where
     })
 }
 
-fn material_postprocess(materials: &mut [MaterialData]) {
+/// Each [`MaterialPass`] needs to have it's material name be
+/// set from the parent material. This is hard to do in serde, so
+/// serde ignores it and it is set in this pass.
+fn set_material_pass_material_name(materials: &mut [MaterialData]) {
     for mat in materials {
         for pass in &mut mat.passes {
             pass.material_name = mat.name.clone();
@@ -233,20 +286,29 @@ fn material_postprocess(materials: &mut [MaterialData]) {
     }
 }
 
+/// During loading, a ShaderSource is a path to a shader file. These have been
+/// loaded into an array of shader sources. Using the mapping of path to index we generated before,
+/// we not replace the path with a index.
 fn pipeline_postprocess(pipelines: &mut [PipelineCreationInfo], shader_mapping: HashMap<&PathBuf, u32>) {
+    // A helpful closure that processes a single shader. Needs to be a closure
+    // because it captures the surrounding arguments.
     let process_shader = |shader: &mut ShaderSource| {
         if let ShaderSource::Path(name) = shader {
             *shader = match shader_mapping.get(name) {
                 Some(index) => ShaderSource::Loaded(*index),
                 None => ShaderSource::Invalid,
             }
+        } else {
+            panic!("Invalid ShaderSource state. {:?}", shader);
         }
     };
 
+    // Forwarding wrapper that unwraps an optional shader.
     let process_shader_option = |shader_option: &mut Option<ShaderSource>| {
         if let Some(shader) = shader_option {
             process_shader(shader)
         }
+        // Does nothing if it doesn't exist
     };
 
     for pipeline in pipelines {
@@ -258,6 +320,8 @@ fn pipeline_postprocess(pipelines: &mut [PipelineCreationInfo], shader_mapping: 
     }
 }
 
+/// Helper function that enumerates the contents of a folder. Is a wrapper for [`FileTree::read_dir`]
+/// that also properly changes the errors to the proper format
 fn enumerate_folder<T, P>(tree: &T, path: P) -> Result<HashSet<PathBuf>, ShaderpackLoadingFailure>
 where
     T: FileTree,
@@ -270,18 +334,29 @@ where
     })
 }
 
+/// Helper function that loads an json file from the file tree, then uses serde to deserialize it into
+/// R. It then properly deals with that error. The type to deserialize into is through return type deduction,
+/// so to invoke by an executor macro, you need to use superfish.
 async fn load_json<R, T>(tree: T, path: PathBuf) -> Result<R, ShaderpackLoadingFailure>
 where
     R: serde::de::DeserializeOwned + Send,
     T: FileTree + Send,
 {
+    // Load the json file, we need the result immediately before we can proceed, so await it.
+    // This isn't launched on the executor because it is not an async function itself, it's
+    // a piece of async io.
     let rp_file_result: Result<Vec<u8>, _> = tree.read(path.as_ref()).await;
+
+    // Convert the errors
     let rp_file = rp_file_result.map_err(|err| match err {
         LoadingError::NotFile => ShaderpackLoadingFailure::NotFile(path.clone().into_os_string()),
         LoadingError::FileSystemError { sub_error } => ShaderpackLoadingFailure::FileSystemError { sub_error },
         LoadingError::PathNotFound => ShaderpackLoadingFailure::MissingFile(path.clone().into_os_string()),
         e => ShaderpackLoadingFailure::UnknownError { sub_error: e.into() },
     })?;
+
+    // Deserialize the json
     let parsed: Result<R, _> = serde_json::from_slice(&rp_file);
+    // Map the json error
     parsed.map_err(|err| ShaderpackLoadingFailure::JsonError(path.into_os_string(), err))
 }

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -186,7 +186,15 @@ where
         }
     }
 
-    let shaders_folder = enumerate_folder(&tree, "shaders")?;
+    let shaders_folder: HashSet<PathBuf> = enumerate_folder(&tree, "shaders")?
+        .into_iter()
+        .map(|path| {
+            let mut p = PathBuf::new();
+            p.push("shaders");
+            p.push(path);
+            p
+        })
+        .collect();
 
     let shader_futs: Vec<_> = shaders_folder.iter().map(|p| tree.read_text(p)).collect();
     let shader_mapping: HashMap<&PathBuf, u32> =

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -9,6 +9,7 @@ use crate::loading::{DirectoryFileTree, FileTree, LoadingError};
 use failure::Error;
 use failure::Fail;
 use futures::task::SpawnExt;
+use path_dsl::path;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -166,12 +167,7 @@ where
     let mut pipelines_futs = Vec::new();
 
     for path in materials_folder {
-        let full_path = {
-            let mut p = PathBuf::new();
-            p.push("materials");
-            p.push(&path);
-            p
-        };
+        let full_path = path!("materials" | &path).into();
         let ext = path.extension().and_then(|s| s.to_str());
         match ext {
             Some("mat") => {
@@ -188,12 +184,7 @@ where
 
     let shaders_folder: HashSet<PathBuf> = enumerate_folder(&tree, "shaders")?
         .into_iter()
-        .map(|path| {
-            let mut p = PathBuf::new();
-            p.push("shaders");
-            p.push(path);
-            p
-        })
+        .map(|path| path!("shaders" | path).into())
         .collect();
 
     let shader_futs: Vec<_> = shaders_folder.iter().map(|p| tree.read_text(p)).collect();

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -1,6 +1,6 @@
 //! Loaders for user shaderpacks.
 //!
-//! There is currently a single entrypoint: [`load_nova_shaderpack`].
+//! There is currently a single entrypoint: [`load_nova_shaderpack`](shaderpack::load_nova_shaderpack).
 //! Use this function to load a shaderpack from disk.
 //!
 //! TOOD(cwfitzgerald): Unify shaderpack entrypoints.

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -98,12 +98,22 @@ async fn load_nova_shaderpack_impl<'a, T: FileTree<'a>>(
         }
     }
 
+    material_postprocess(&mut materials);
+
     Ok(ShaderpackData {
         passes,
         resources,
         materials,
         pipelines,
     })
+}
+
+fn material_postprocess(materials: &mut [MaterialData]) {
+    for mat in materials {
+        for pass in &mut mat.passes {
+            pass.material_name = mat.name.clone();
+        }
+    }
 }
 
 fn enumerate_folder<'a, T, P>(tree: &'a T, path: P) -> Result<HashSet<&'a Path>, ShaderpackLoadingFailure>

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -3,9 +3,7 @@
 use crate::loading::{DirectoryFileTree, FileTree, LoadingError};
 use failure::Error;
 use failure::Fail;
-use futures::future::{join_all, RemoteHandle};
 use futures::task::SpawnExt;
-use futures::StreamExt;
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -13,8 +11,10 @@ use std::path::{Path, PathBuf};
 mod structs;
 pub use structs::*;
 
+/// Failure type for shaderpack loading.
 #[derive(Fail, Debug)]
 pub enum ShaderpackLoadingFailure {
+    /// Path to the root of the shaderpack not found
     #[fail(display = "Path to shaderpack not found: {:?}", _0)]
     PathNotFound(PathBuf),
 

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -77,13 +77,19 @@ pub async fn load_nova_shaderpack(path: PathBuf) -> Result<ShaderpackData, Shade
 async fn load_nova_shaderpack_impl<'a, T: FileTree<'a>>(
     tree: &'a T,
 ) -> Result<ShaderpackData, ShaderpackLoadingFailure> {
-    let passes: Vec<RenderPassCreationInfo> = load_json(tree, &"/passes.json").await?;
-    let resources: ShaderpackResourceData = load_json(tree, &"/resources.json").await?;
-    let materials_folder = enumerate_folder(tree, &"/materials")?;
+    let passes: Vec<RenderPassCreationInfo> = load_json(tree, &"passes.json").await?;
+    let resources: ShaderpackResourceData = load_json(tree, &"resources.json").await?;
+    let materials_folder = enumerate_folder(tree, &"materials")?;
     let mut materials: Vec<MaterialData> = Vec::new();
     let mut pipelines: Vec<PipelineCreationInfo> = Vec::new();
     for path in materials_folder {
-        let full_path = format!("/materials/{}", path.to_string_lossy());
+        let full_path = {
+            let mut p = PathBuf::new();
+            p.push("materials");
+            p.push(path);
+            p
+        };
+
         let ext = path.extension().and_then(|s| s.to_str());
         match ext {
             Some("mat") => materials.push(load_json(tree, full_path).await?),

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -1,4 +1,9 @@
-//! Shaderpack loaders.
+//! Loaders for user shaderpacks.
+//!
+//! There is currently a single entrypoint: [`load_nova_shaderpack`].
+//! Use this function to load a shaderpack from disk.
+//!
+//! TOOD(cwfitzgerald): Unify shaderpack entrypoints.
 
 use crate::loading::{DirectoryFileTree, FileTree, LoadingError};
 use failure::Error;

--- a/src/shaderpack/mod.rs
+++ b/src/shaderpack/mod.rs
@@ -1,805 +1,89 @@
 //! Shaderpack loaders.
 
-use cgmath::Vector2;
-use serde::Deserialize;
-use std::collections::HashMap;
-use std::path::PathBuf;
+use crate::loading::{DirectoryFileTree, FileTree, LoadingError};
+use failure::Error;
+use failure::Fail;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
-/// A fully parsed Nova Shaderpack
-#[derive(Debug, Clone)]
-pub struct ShaderpackData {
-    /// The pipelines that this shaderpack specifies.
-    pipelines: Vec<PipelineCreationInfo>,
+mod structs;
+pub use structs::*;
 
-    /// The renderpasses that this shaderpack specifies, in submission order.
-    passes: Vec<RenderPassCreationInfo>,
+#[derive(Fail, Debug)]
+pub enum ShaderpackLoadingFailure {
+    #[fail(display = "Path to shaderpack not found: {:?}", _0)]
+    PathNotFound(PathBuf),
 
-    /// The materials that this shaderpack specifies.
-    materials: Vec<MaterialData>,
+    #[fail(display = "Unsupported shaderpack extension {:?}", _0)]
+    UnsupportedExtension(OsString),
 
-    /// The resources that this shaderpack specifies.
-    resources: ShaderpackResourceData,
+    #[fail(display = "File {:?} not found in shaderpack.", _0)]
+    MissingFile(OsString),
+
+    #[fail(display = "File {:?} not found in shaderpack.", _0)]
+    MissingDirectory(OsString),
+
+    #[fail(display = "Error while parsing json {:?}", _0)]
+    JsonError(serde_json::Error),
+
+    #[fail(display = "Directory member is a file not a directory {:?}", _0)]
+    NotDirectory(OsString),
+
+    #[fail(display = "Directory member is a directory not a file {:?}", _0)]
+    NotFile(OsString),
+
+    #[fail(display = "Unknown internal error: {:?}", sub_error)]
+    UnknownError {
+        /// Actual error
+        #[fail(cause)]
+        sub_error: Error,
+    },
+
+    /// Error within the filesystem.
+    #[fail(display = "Unknown filesystem error: {:?}", sub_error)]
+    FileSystemError {
+        /// Actual error
+        #[fail(cause)]
+        sub_error: Error,
+    },
 }
 
-/// Information needed to create a pipeline
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PipelineCreationInfo {
-    /// The name of this pipeline.
-    name: String,
-
-    /// The pipeline that this pipeline inherits from.
-    parent: Option<String>,
-
-    /// The name of the pass that this pipeline belongs to.
-    pass: String,
-
-    /// All of the symbols in the shader that are defined by this state.
-    defines: Vec<String>,
-
-    /// Defines the rasterizer state that's active for this pipeline.
-    states: Vec<RasterizerState>,
-
-    /// Sets up the vertex fields that Nova will bind to this pipeline.
-    vertex_fields: Vec<VertexFieldData>,
-
-    /// The stencil buffer operations to perform on the front faces.
-    front_face: Option<StencilOpState>,
-
-    /// The stencil buffer operations to perform on the back faces.
-    back_face: Option<StencilOpState>,
-
-    /// The material to use if this one's shaders can't be found.
-    fallback: Option<String>,
-
-    /// A bias to apply to the depth.
-    #[serde(default = "PipelineCreationInfo::default_depth_bias")]
-    depth_bias: f32,
-
-    /// The depth bias, scaled by slope I guess?
-    #[serde(default = "PipelineCreationInfo::default_slope_scaled_depth_bias")]
-    slope_scaled_depth_bias: f32,
-
-    /// The reference value to use for the stencil test.
-    #[serde(default = "PipelineCreationInfo::default_stencil_ref")]
-    stencil_ref: u32,
-
-    /// The mask to use when reading from the stencil buffer.
-    #[serde(default = "PipelineCreationInfo::default_stencil_read_mask")]
-    stencil_read_mask: u32,
-
-    /// The mask to use when writing to the stencil buffer.
-    #[serde(default = "PipelineCreationInfo::default_stencil_write_mask")]
-    stencil_write_mask: u32,
-
-    /// How to handle MSAA for this state.
-    #[serde(default = "PipelineCreationInfo::default_msaa_support")]
-    msaa_support: MSAASupport,
-
-    /// Decides how the vertices are rendered.
-    #[serde(default = "PipelineCreationInfo::default_primitive_mode")]
-    primitive_mode: PrimitiveTopology,
-
-    /// Where to get the blending factor for the source.
-    #[serde(default = "PipelineCreationInfo::default_src_blend_factor")]
-    src_blend_factor: BlendFactor,
-
-    /// Where to get the blending factor for the destination.
-    #[serde(default = "PipelineCreationInfo::default_dst_blend_factor")]
-    dst_blend_factor: BlendFactor,
-
-    /// How to get the source alpha in a blend.
-    #[serde(default = "PipelineCreationInfo::default_alpha_src")]
-    alpha_src: BlendFactor,
-
-    /// How to get the destination alpha in a blend.
-    #[serde(rename = "alphaDest")]
-    #[serde(default = "PipelineCreationInfo::default_alpha_dst")]
-    alpha_dst: BlendFactor,
-
-    /// The function to use for the depth test.
-    #[serde(default = "PipelineCreationInfo::default_depth_func")]
-    depth_func: CompareOp,
-
-    /// The render queue that this pass belongs to.
-    /// This may or may not be removed depending on what is actually needed by Nova.
-    #[serde(default = "PipelineCreationInfo::default_render_queue")]
-    render_queue: RenderQueue,
-
-    /// Vertex shader to use.
-    #[serde(default = "PipelineCreationInfo::default_vertex_shader")]
-    vertex_shader: ShaderSource,
-
-    /// Geometry shader to use.
-    geometry_shader: Option<ShaderSource>,
-
-    /// Tessellation Control shader to use.
-    tessellation_control_shader: Option<ShaderSource>,
-
-    /// Tessellation Evaluation shader to use.
-    tessellation_evaluation_shader: Option<ShaderSource>,
-
-    /// Fragment shader to use.
-    fragment_shader: Option<ShaderSource>,
-}
-
-impl PipelineCreationInfo {
-    fn default_depth_bias() -> f32 {
-        0.0
-    }
-    fn default_slope_scaled_depth_bias() -> f32 {
-        0.0
-    }
-    fn default_stencil_ref() -> u32 {
-        0
-    }
-    fn default_stencil_read_mask() -> u32 {
-        0
-    }
-    fn default_stencil_write_mask() -> u32 {
-        0
-    }
-    fn default_msaa_support() -> MSAASupport {
-        MSAASupport::None
-    }
-    fn default_primitive_mode() -> PrimitiveTopology {
-        PrimitiveTopology::Triangles
-    }
-    fn default_src_blend_factor() -> BlendFactor {
-        BlendFactor::One
-    }
-    fn default_dst_blend_factor() -> BlendFactor {
-        BlendFactor::Zero
-    }
-    fn default_alpha_src() -> BlendFactor {
-        BlendFactor::One
-    }
-    fn default_alpha_dst() -> BlendFactor {
-        BlendFactor::Zero
-    }
-    fn default_depth_func() -> CompareOp {
-        CompareOp::Less
-    }
-    fn default_render_queue() -> RenderQueue {
-        RenderQueue::Opaque
-    }
-    fn default_vertex_shader() -> ShaderSource {
-        ShaderSource {
-            filename: PathBuf::from("<NAME_MISSING>"),
-            source: Vec::new(),
+pub async fn load_nova_shaderpack(path: PathBuf) -> Result<ShaderpackData, ShaderpackLoadingFailure> {
+    match (path.exists(), path.is_dir(), path.extension()) {
+        (true, true, _) => {
+            let file_tree_res: Result<DirectoryFileTree, _> = DirectoryFileTree::from_path(&path).await;
+            let file_tree = file_tree_res.map_err(|err| match err {
+                LoadingError::ResourceNotFound => ShaderpackLoadingFailure::PathNotFound(path),
+                LoadingError::FileSystemError { sub_error: e } => {
+                    ShaderpackLoadingFailure::FileSystemError { sub_error: e }
+                }
+                e => ShaderpackLoadingFailure::UnknownError { sub_error: e.into() },
+            })?;
+            load_nova_shaderpack_impl(&file_tree).await
         }
-    }
-
-    /// Merge a shaderpack with a "parent" shaderpack. Unimplemented.
-    ///
-    /// # Parameters
-    ///
-    /// - `_other` - Shaderpack to merge with.
-    pub fn merge_with_parent(&mut self, _other: &PipelineCreationInfo) -> Self {
-        unimplemented!()
+        (true, false, Some(ext)) if ext == "zip" => unimplemented!(),
+        (true, false, Some(ext)) => Err(ShaderpackLoadingFailure::UnsupportedExtension(ext.to_owned())),
+        (true, false, None) => Err(ShaderpackLoadingFailure::UnsupportedExtension("<blank>".into())),
+        (false, _, _) => Err(ShaderpackLoadingFailure::PathNotFound(path)),
     }
 }
 
-/// A pass over the scene.
-///
-/// A pass has a few things:
-/// - What passes MUST be executed before this one.
-/// - What inputs this pass's shaders have:
-///      - What uniform buffers to use.
-///      - What vertex data to use.
-///      - Any textures that are needed.
-/// - What outputs this pass has:
-///      - Framebuffer attachments.
-///      - Write buffers.
-///
-/// The inputs and outputs of a pass must be resources declared in the shaderpack's `resources.json` file (or the
-/// default resources.json), or a resource that's internal to Nova. For example, Nova provides a UBO of uniforms that
-/// change per frame, a UBO for per-model data like the model matrix, and the virtual texture atlases. The default
-/// resources.json file sets up sixteen framebuffer color attachments for ping-pong buffers, a depth attachment,
-/// some shadow maps, etc.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RenderPassCreationInfo {
-    /// The name of this render pass.
-    #[serde(default = "RenderPassCreationInfo::default_name")]
-    name: String,
-
-    /// The materials that MUST execute before this one.
-    dependencies: Vec<String>,
-
-    /// The textures that this pass will read from.
-    texture_inputs: Vec<String>,
-
-    /// The textures that this pass will write to.
-    texture_outputs: Vec<TextureAttachmentInfo>,
-
-    /// The depth texture this pass will write to.
-    depth_texture: Option<TextureAttachmentInfo>,
-
-    /// All the buffers that this renderpass reads from.
-    input_buffers: Vec<String>,
-
-    /// All the buffers that this renderpass writes to.
-    output_buffers: Vec<String>,
+async fn load_nova_shaderpack_impl<'a, T: FileTree<'a>>(tree: &T) -> Result<ShaderpackData, ShaderpackLoadingFailure> {
+    let renderpasses = load_nova_renderpasses(tree).await;
+    unimplemented!()
 }
 
-impl RenderPassCreationInfo {
-    fn default_name() -> String {
-        String::from("<NAME_MISSING>")
-    }
-}
-
-/// A single renderable material.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MaterialData {
-    /// The name of the material.
-    name: String,
-
-    /// The information needed for each renderpass the material is in.
-    passes: Vec<MaterialPass>,
-
-    /// Name of the geometry filter to use.
-    geometry_filter: String,
-}
-
-/// Holds all resources that are required by the shaderpack.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ShaderpackResourceData {
-    /// Specification for needed textures.
-    textures: Vec<TextureCreateInfo>,
-
-    /// Specification for needed samplers.
-    samplers: Vec<SamplerCreateInfo>,
-}
-
-/// Connects a [`VertexField`] with a semantic name.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VertexFieldData {
-    /// Name of the vertex field.
-    semantic_name: String,
-
-    /// Type of vertex data.
-    field: VertexField,
-}
-
-/// State of all the stencil operations.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StencilOpState {
-    /// Operation if stencil test fails.
-    #[serde(default = "StencilOpState::default_fail_op")]
-    fail_op: StencilOp,
-
-    /// Operation if stencil test passes.
-    #[serde(default = "StencilOpState::default_pass_op")]
-    pass_op: StencilOp,
-
-    /// Operation if depth test fails.
-    #[serde(default = "StencilOpState::default_depth_fail_op")]
-    depth_fail_op: StencilOp,
-
-    /// Comparison with the stencil buffer.
-    #[serde(default = "StencilOpState::default_compare_op")]
-    compare_op: CompareOp,
-
-    /// Stencil buffer comparison mask.
-    #[serde(default = "StencilOpState::default_compare_mask")]
-    compare_mask: u32,
-
-    /// Stencil buffer write mask.
-    #[serde(default = "StencilOpState::default_write_mask")]
-    write_mask: u32,
-}
-
-impl StencilOpState {
-    fn default_fail_op() -> StencilOp {
-        StencilOp::Keep
-    }
-    fn default_pass_op() -> StencilOp {
-        StencilOp::Keep
-    }
-    fn default_depth_fail_op() -> StencilOp {
-        StencilOp::Keep
-    }
-    fn default_compare_op() -> CompareOp {
-        CompareOp::Equal
-    }
-    fn default_compare_mask() -> u32 {
-        0
-    }
-    fn default_write_mask() -> u32 {
-        0
-    }
-}
-
-/// Shader source file as a compiled SPIR-V file.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ShaderSource {
-    /// Filename of the shader source file.
-    filename: PathBuf,
-
-    /// Compiled SPIR-V shader.
-    #[serde(skip)]
-    source: Vec<u32>,
-}
-
-/// A description of a texture that a render pass outputs to.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TextureAttachmentInfo {
-    ///  The name of the texture.
-    name: String,
-
-    /// Pixel format of the texture.
-    #[serde(default = "TextureAttachmentInfo::default_pixel_format")]
-    pixel_format: PixelFormat,
-
-    /// Whether to clear the texture.
-    ///
-    /// If the texture is a depth buffer, it gets cleared to 1.
-    /// If the texture is a stencil buffer, it gets cleared to 0xFFFFFFFF.
-    /// If the texture is a color buffer, it gets cleared to (0, 0, 0, 0).
-    #[serde(default = "TextureAttachmentInfo::default_clear")]
-    clear: bool,
-}
-
-impl TextureAttachmentInfo {
-    fn default_pixel_format() -> PixelFormat {
-        PixelFormat::RGBA8
-    }
-    fn default_clear() -> bool {
-        false
-    }
-}
-
-/// The per-renderpass data for a material
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MaterialPass {
-    /// Name of the render pass.
-    name: String,
-
-    /// Name of the material itself.
-    ///
-    /// This is not populated by serde, this is populated by a post processing pass _after_ serde.
-    ///
-    /// TODO(cwfitzgerald): Which function does that?
-    #[serde(default)]
-    material_name: String,
-
-    /// Name of the pipeline.
-    pipeline: String,
-
-    /// All named bindings for this renderpass.
-    bindings: HashMap<String, String>,
-}
-
-/// Description of a texture
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TextureCreateInfo {
-    /// The name of the texture.
-    ///
-    /// Nova implicitly defines a few textures for you to use:
-    /// - `ColorVirtualTexture`:
-    ///      - Virtual texture atlas that holds color textures.
-    ///      - Textures which have the exact name as requested by Minecraft are in this atlas.
-    ///      - Things without a color texture get a pure white texture.
-    ///      - Always has a format of `RGBA8`.
-    ///      - Can only be used as a pass's input.
-    /// - `NormalVirtualTexture`:
-    ///      - Virtual texture atlas that holds normal textures.
-    ///      - Textures which have `_n` after the name requested by Minecraft are in this atlas.
-    ///      - If no normal texture exists for a given object, a texture with RGBA of (0, 0, 1, 1) is used.
-    ///      - Always has a format of `RGBA8`.
-    ///      - Can only be used as a pass's input.
-    /// - `DataVirtualTexture`:
-    ///      - Virtual texture atlas that holds data textures.
-    ///      - Textures which have a `_s` after the name requested by Minecraft are in this atlas.
-    ///      - If no data texture exists for a given object, a texture with an RGBA of (0, 0, 0, 0) is used.
-    ///      - Always has a format of `RGBA8`.
-    ///      - Can only be used as a pass's input.
-    /// - `Lightmap`:
-    ///      - Lightmap, loaded from the current resourcepack.
-    ///      - Format of RGB8.
-    ///      - Can only be used as an input.
-    /// - `Backbuffer`:
-    ///      - The texture that gets presented to the screen.
-    ///      - Always has a format of RGB8.
-    ///      - Can only be used as a pass's output.
-    ///
-    /// If you use one of the virtual textures, then all fields except the binding are ignored.
-    ///
-    /// If you use `Backbuffer`, then all fields are ignored since the backbuffer is always bound to output location 0.
-    ///
-    /// TODO(cwfitzgerald): This can have a more elegant representation with an enum
-    name: String,
-
-    /// Texture format for the image.
-    ///
-    /// All members except the bindings are ignored if the texture is virtual. Everything is
-    /// ignored if the texture is the BackBuffer.
-    format: TextureFormat,
-}
-
-/// Defines a sampler to use for a texture.
-///
-/// At the time of writing I'm not sure how this is correlated with a texture, but all well.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SamplerCreateInfo {
-    /// String name of the sampler.
-    #[serde(default = "SamplerCreateInfo::default_name")]
-    name: String,
-
-    /// What kind of texture filter to use.
-    ///
-    /// texel_aa does something that I don't want to figure out right now. Bilinear is your regular bilinear filter,
-    /// and point is the point filter. Aniso isn't an option and I kinda hope it stays that way.
-    #[serde(default = "SamplerCreateInfo::default_filter")]
-    filter: TextureFilter,
-
-    /// How the texture should wrap at the edges.
-    #[serde(default = "SamplerCreateInfo::default_wrap_mode")]
-    wrap_mode: WrapMode,
-}
-
-impl SamplerCreateInfo {
-    fn default_name() -> String {
-        String::new()
-    }
-    fn default_filter() -> TextureFilter {
-        TextureFilter::Point
-    }
-    fn default_wrap_mode() -> WrapMode {
-        WrapMode::Clamp
-    }
-}
-
-/// The formatting information of a texture in memory.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TextureFormat {
-    /// The format of the texture.
-    #[serde(default = "TextureFormat::default_pixel_format")]
-    pixel_format: PixelFormat,
-
-    /// How to interpret the dimensions of this texture.
-    #[serde(default = "TextureFormat::default_dimension_type")]
-    dimension_type: TextureDimensionType,
-
-    /// The width, in pixels, of the texture.
-    #[serde(default = "TextureFormat::default_width")]
-    width: f32,
-
-    /// The height, in pixels, of the texture.
-    #[serde(default = "TextureFormat::default_height")]
-    height: f32,
-}
-
-impl TextureFormat {
-    fn default_pixel_format() -> PixelFormat {
-        PixelFormat::RGBA8
-    }
-    fn default_dimension_type() -> TextureDimensionType {
-        TextureDimensionType::ScreenRelative
-    }
-    fn default_width() -> f32 {
-        0.0
-    }
-    fn default_height() -> f32 {
-        0.0
-    }
-
-    /// Returns the screen size in pixels.
-    ///
-    /// # Parameters
-    ///
-    /// - `screen_size` - Needed if the texture resolution is relative to the screen size
-    pub fn get_size_in_pixels(&self, screen_size: Vector2<f32>) -> Vector2<f32> {
-        let (width, height) = match self.dimension_type {
-            TextureDimensionType::ScreenRelative => (self.width * screen_size.x, self.height * screen_size.y),
-            TextureDimensionType::Absolute => (self.width, self.height),
-        };
-
-        Vector2::new(width.round(), height.round())
-    }
-}
-
-/// Rasterizer hardware features that shaderpacks can enable.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum RasterizerState {
-    /// Enable blending for this material state.
-    Blending,
-
-    /// Render backfaces and cull frontfaces.
-    InvertCulling,
-
-    /// Don't cull backfaces or frontfaces.
-    DisableCulling,
-
-    /// Don't write to the depth buffer.
-    DisableDepthWrite,
-
-    /// Don't perform a depth test.
-    DisableDepthTest,
-
-    /// Perform the stencil test.
-    EnableStencilTest,
-
-    /// Write to the stencil buffer.
-    StencilWrite,
-
-    /// Don't write to the color buffer.
-    DisableColorWrite,
-
-    /// Enable alpha to coverage.
-    EnableAlphaToCoverage,
-
-    /// Don't write alpha.
-    DisableAlphaWrite,
-}
-
-/// Multisample Antialiasing mode.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum MSAASupport {
-    /// Enable MSAA.
-    MSAA,
-
-    /// Disable antialiasing.
-    None,
-}
-
-/// Primitive to interpret vertex buffer as.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum PrimitiveTopology {
-    /// Rasterize triangles.
-    Triangles,
-
-    /// Rasterize lines.
-    Lines,
-}
-
-/// How to blend the new image with the old image.
-///
-/// See [opengl wiki](https://www.khronos.org/opengl/wiki/Blending#Blend_Equations) for more info.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum BlendFactor {
-    /// 1 * color
-    One,
-
-    /// 0 * color
-    Zero,
-
-    /// Pull from source color.
-    SrcColor,
-
-    /// Pull from destination color.
-    DstColor,
-
-    /// 1 - src
-    OneMinusSrcColor,
-
-    /// 1 - dst
-    OneMinusDstColor,
-
-    /// Pull from source alpha.
-    SrcAlpha,
-
-    /// Pull from destination alpha.
-    DstAlpha,
-
-    /// 1 - srcA
-    OneMinusSrcAlpha,
-
-    /// 1 - dstA
-    OneMinusDstAlpha,
-}
-
-/// Comparator used for fixed function operations.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum CompareOp {
-    /// false
-    Never,
-
-    /// a < b
-    Less,
-
-    /// a <= b
-    LessEqual,
-
-    /// a > b
-    Greater,
-
-    /// a >= b
-    GreaterEqual,
-
-    /// a == b
-    Equal,
-
-    /// a != b
-    NotEqual,
-
-    /// true
-    Always,
-}
-
-/// Objects join a queue based on the type of transparency they need.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum RenderQueue {
-    /// Full alpha transparency.
-    Transparent,
-
-    /// No transparency.
-    Opaque,
-
-    /// Cutout transparency (full transparent or opaque).
-    Cutout,
-}
-
-/// Identifier for a type and data format for vertex data.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum VertexField {
-    /// The vertex position.
-    ///
-    /// 12 bytes
-    Position,
-
-    /// The vertex color.
-    ///
-    /// 4 bytes.
-    Color,
-
-    /// The UV coordinate of this object.
-    ///
-    /// Except not really, because Nova's virtual textures means that the UVs for a block or entity or whatever
-    /// could change on the fly, so this is kinda more of a preprocessor define that replaces the UV with a lookup
-    /// in the UV table.
-    ///
-    /// 8 bytes (might try 4).
-    UV0,
-
-    /// The UV coordinate in the lightmap texture.
-    ///
-    /// This is a real UV and it doesn't change for no good reason.
-    ///
-    /// 2 bytes.
-    UV1,
-
-    /// Vertex normal.
-    ///
-    /// 12 bytes.
-    Normal,
-
-    /// Vertex tangents.
-    ///
-    /// 12 bytes.
-    Tangent,
-
-    /// The texture coordinate of the middle of the quad.
-    ///
-    /// 8 bytes
-    MidTexCoord,
-
-    /// A uint32_t that's a unique identifier for the texture that this vertex uses.
-    ///
-    /// This is generated at runtime by Nova, so it may change a lot depending on what resourcepacks are loaded and
-    /// if they use CTM or random detail textures or whatever.
-    ///
-    /// 4 bytes.
-    VirtualTextureId,
-
-    /// Some information about the current block/entity/whatever.
-    ///
-    /// 12 bytes
-    McEntityId,
-}
-
-/// Which operation to determine the value of the stencil buffer after a write.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum StencilOp {
-    /// Do not change the stencil buffer.
-    Keep,
-
-    /// Set the stencil buffer to zero.
-    Zero,
-
-    /// Replace the stencil buffer with the current replacement value.
-    Replace,
-
-    /// Increments the stencil buffer value.
-    Incr,
-
-    /// Increments the stencil buffer value, wrapping around to zero on overflow.
-    IncrWrap,
-
-    /// Decrements the stencil buffer value.
-    Decr,
-
-    /// Decrements the stencil buffer value, wrapping around to 2^n-1 on underflow.
-    DecrWrap,
-
-    /// Bitwise invert the current stencil value.
-    Invert,
-}
-
-/// Layout of pixels in memory
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum PixelFormat {
-    /// R, G, B, and A channels, all taking up 8 bits integers each. 4 bytes.
-    RGBA8,
-
-    /// R, G, B, and A channels, all taking up 16 bits floats each. 8 bytes.
-    RGBA16F,
-
-    /// R, G, B, and A channels, all taking up 32 bits floats each. 16 bytes.
-    RGBA32F,
-
-    /// Depth channel only.
-    Depth,
-
-    /// Depth and stencil channel.
-    DepthStencil,
-}
-
-/// Filter to use when reading from texture.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum TextureFilter {
-    /// Bedrock features texel manipulation based AA.
-    TexelAA,
-
-    /// Bilinear filtering.
-    Bilinear,
-
-    /// Normal filtering.
-    Point,
-}
-
-/// Texture wrap mode.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum WrapMode {
-    /// Repeat the texture when out of UV bounds.
-    Repeat,
-
-    /// Clamp to the edge of the UV when out of UV bounds.
-    Clamp,
-}
-
-/// Frame of reference for texture dimensions.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum TextureDimensionType {
-    /// Dimensions are relative to the screen to allow screen space textures of the appropriate size.
-    ScreenRelative,
-
-    /// Dimensions are absolute.
-    Absolute,
-}
-
-/// Origin location of a texture
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum TextureLocation {
-    /// The texture is written to by a shader.
-    Dynamic,
-
-    /// The texture is loaded from the textures/ folder in the current shaderpack.
-    InUserPackage,
-
-    /// The texture is provided by Nova or by Minecraft.
-    InAppPackage,
+async fn load_nova_renderpasses<'a, T: FileTree<'a>>(
+    tree: &T,
+) -> Result<RenderPassCreationInfo, ShaderpackLoadingFailure> {
+    let path = Path::new("/passes.json");
+    let rp_file_result: Result<Vec<u8>, _> = tree.read(Path::new("/passes.json")).await;
+    let rp_file = rp_file_result.map_err(|err| match err {
+        LoadingError::NotFile => ShaderpackLoadingFailure::NotFile(path.into()),
+        LoadingError::FileSystemError { sub_error } => ShaderpackLoadingFailure::FileSystemError { sub_error },
+        LoadingError::PathNotFound => ShaderpackLoadingFailure::MissingFile(path.into()),
+        e => ShaderpackLoadingFailure::UnknownError { sub_error: e.into() },
+    })?;
+    let parsed: Result<RenderPassCreationInfo, _> = serde_json::from_slice(&rp_file);
+    parsed.map_err(|err| ShaderpackLoadingFailure::JsonError(err))
 }

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -27,27 +27,33 @@ pub struct PipelineCreationInfo {
     pub name: String,
 
     /// The pipeline that this pipeline inherits from.
+    #[serde(default)]
     pub parent: Option<String>,
 
     /// The name of the pass that this pipeline belongs to.
     pub pass: String,
 
     /// All of the symbols in the shader that are defined by this state.
+    #[serde(default)]
     pub defines: Vec<String>,
 
     /// Defines the rasterizer state that's active for this pipeline.
+    #[serde(default)]
     pub states: Vec<RasterizerState>,
 
     /// Sets up the vertex fields that Nova will bind to this pipeline.
     pub vertex_fields: Vec<VertexFieldData>,
 
     /// The stencil buffer operations to perform on the front faces.
+    #[serde(default)]
     pub front_face: Option<StencilOpState>,
 
     /// The stencil buffer operations to perform on the back faces.
+    #[serde(default)]
     pub back_face: Option<StencilOpState>,
 
     /// The material to use if this one's shaders can't be found.
+    #[serde(default)]
     pub fallback: Option<String>,
 
     /// A bias to apply to the depth.
@@ -109,15 +115,19 @@ pub struct PipelineCreationInfo {
     pub vertex_shader: ShaderSource,
 
     /// Geometry shader to use.
+    #[serde(default)]
     pub geometry_shader: Option<ShaderSource>,
 
     /// Tessellation Control shader to use.
+    #[serde(default)]
     pub tessellation_control_shader: Option<ShaderSource>,
 
     /// Tessellation Evaluation shader to use.
+    #[serde(default)]
     pub tessellation_evaluation_shader: Option<ShaderSource>,
 
     /// Fragment shader to use.
+    #[serde(default)]
     pub fragment_shader: Option<ShaderSource>,
 }
 
@@ -200,21 +210,27 @@ pub struct RenderPassCreationInfo {
     pub name: String,
 
     /// The materials that MUST execute before this one.
+    #[serde(default)]
     pub dependencies: Vec<String>,
 
     /// The textures that this pass will read from.
+    #[serde(default)]
     pub texture_inputs: Vec<String>,
 
     /// The textures that this pass will write to.
+    #[serde(default)]
     pub texture_outputs: Vec<TextureAttachmentInfo>,
 
     /// The depth texture this pass will write to.
+    #[serde(default)]
     pub depth_texture: Option<TextureAttachmentInfo>,
 
     /// All the buffers that this renderpass reads from.
+    #[serde(default, rename = "bufferInputs")]
     pub input_buffers: Vec<String>,
 
     /// All the buffers that this renderpass writes to.
+    #[serde(default, rename = "bufferOutputs")]
     pub output_buffers: Vec<String>,
 }
 
@@ -235,6 +251,7 @@ pub struct MaterialData {
     pub passes: Vec<MaterialPass>,
 
     /// Name of the geometry filter to use.
+    #[serde(rename = "filter")]
     pub geometry_filter: String,
 }
 
@@ -253,6 +270,7 @@ pub struct ShaderpackResourceData {
 #[serde(rename_all = "camelCase")]
 pub struct VertexFieldData {
     /// Name of the vertex field.
+    #[serde(rename = "name")]
     pub semantic_name: String,
 
     /// Type of vertex data.

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -1,0 +1,803 @@
+use cgmath::Vector2;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// A fully parsed Nova Shaderpack
+#[derive(Debug, Clone)]
+pub struct ShaderpackData {
+    /// The pipelines that this shaderpack specifies.
+    pipelines: Vec<PipelineCreationInfo>,
+
+    /// The renderpasses that this shaderpack specifies, in submission order.
+    passes: Vec<RenderPassCreationInfo>,
+
+    /// The materials that this shaderpack specifies.
+    materials: Vec<MaterialData>,
+
+    /// The resources that this shaderpack specifies.
+    resources: ShaderpackResourceData,
+}
+
+/// Information needed to create a pipeline
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineCreationInfo {
+    /// The name of this pipeline.
+    name: String,
+
+    /// The pipeline that this pipeline inherits from.
+    parent: Option<String>,
+
+    /// The name of the pass that this pipeline belongs to.
+    pass: String,
+
+    /// All of the symbols in the shader that are defined by this state.
+    defines: Vec<String>,
+
+    /// Defines the rasterizer state that's active for this pipeline.
+    states: Vec<RasterizerState>,
+
+    /// Sets up the vertex fields that Nova will bind to this pipeline.
+    vertex_fields: Vec<VertexFieldData>,
+
+    /// The stencil buffer operations to perform on the front faces.
+    front_face: Option<StencilOpState>,
+
+    /// The stencil buffer operations to perform on the back faces.
+    back_face: Option<StencilOpState>,
+
+    /// The material to use if this one's shaders can't be found.
+    fallback: Option<String>,
+
+    /// A bias to apply to the depth.
+    #[serde(default = "PipelineCreationInfo::default_depth_bias")]
+    depth_bias: f32,
+
+    /// The depth bias, scaled by slope I guess?
+    #[serde(default = "PipelineCreationInfo::default_slope_scaled_depth_bias")]
+    slope_scaled_depth_bias: f32,
+
+    /// The reference value to use for the stencil test.
+    #[serde(default = "PipelineCreationInfo::default_stencil_ref")]
+    stencil_ref: u32,
+
+    /// The mask to use when reading from the stencil buffer.
+    #[serde(default = "PipelineCreationInfo::default_stencil_read_mask")]
+    stencil_read_mask: u32,
+
+    /// The mask to use when writing to the stencil buffer.
+    #[serde(default = "PipelineCreationInfo::default_stencil_write_mask")]
+    stencil_write_mask: u32,
+
+    /// How to handle MSAA for this state.
+    #[serde(default = "PipelineCreationInfo::default_msaa_support")]
+    msaa_support: MSAASupport,
+
+    /// Decides how the vertices are rendered.
+    #[serde(default = "PipelineCreationInfo::default_primitive_mode")]
+    primitive_mode: PrimitiveTopology,
+
+    /// Where to get the blending factor for the source.
+    #[serde(default = "PipelineCreationInfo::default_src_blend_factor")]
+    src_blend_factor: BlendFactor,
+
+    /// Where to get the blending factor for the destination.
+    #[serde(default = "PipelineCreationInfo::default_dst_blend_factor")]
+    dst_blend_factor: BlendFactor,
+
+    /// How to get the source alpha in a blend.
+    #[serde(default = "PipelineCreationInfo::default_alpha_src")]
+    alpha_src: BlendFactor,
+
+    /// How to get the destination alpha in a blend.
+    #[serde(rename = "alphaDest")]
+    #[serde(default = "PipelineCreationInfo::default_alpha_dst")]
+    alpha_dst: BlendFactor,
+
+    /// The function to use for the depth test.
+    #[serde(default = "PipelineCreationInfo::default_depth_func")]
+    depth_func: CompareOp,
+
+    /// The render queue that this pass belongs to.
+    /// This may or may not be removed depending on what is actually needed by Nova.
+    #[serde(default = "PipelineCreationInfo::default_render_queue")]
+    render_queue: RenderQueue,
+
+    /// Vertex shader to use.
+    #[serde(default = "PipelineCreationInfo::default_vertex_shader")]
+    vertex_shader: ShaderSource,
+
+    /// Geometry shader to use.
+    geometry_shader: Option<ShaderSource>,
+
+    /// Tessellation Control shader to use.
+    tessellation_control_shader: Option<ShaderSource>,
+
+    /// Tessellation Evaluation shader to use.
+    tessellation_evaluation_shader: Option<ShaderSource>,
+
+    /// Fragment shader to use.
+    fragment_shader: Option<ShaderSource>,
+}
+
+impl PipelineCreationInfo {
+    fn default_depth_bias() -> f32 {
+        0.0
+    }
+    fn default_slope_scaled_depth_bias() -> f32 {
+        0.0
+    }
+    fn default_stencil_ref() -> u32 {
+        0
+    }
+    fn default_stencil_read_mask() -> u32 {
+        0
+    }
+    fn default_stencil_write_mask() -> u32 {
+        0
+    }
+    fn default_msaa_support() -> MSAASupport {
+        MSAASupport::None
+    }
+    fn default_primitive_mode() -> PrimitiveTopology {
+        PrimitiveTopology::Triangles
+    }
+    fn default_src_blend_factor() -> BlendFactor {
+        BlendFactor::One
+    }
+    fn default_dst_blend_factor() -> BlendFactor {
+        BlendFactor::Zero
+    }
+    fn default_alpha_src() -> BlendFactor {
+        BlendFactor::One
+    }
+    fn default_alpha_dst() -> BlendFactor {
+        BlendFactor::Zero
+    }
+    fn default_depth_func() -> CompareOp {
+        CompareOp::Less
+    }
+    fn default_render_queue() -> RenderQueue {
+        RenderQueue::Opaque
+    }
+    fn default_vertex_shader() -> ShaderSource {
+        ShaderSource {
+            filename: PathBuf::from("<NAME_MISSING>"),
+            source: Vec::new(),
+        }
+    }
+
+    /// Merge a shaderpack with a "parent" shaderpack. Unimplemented.
+    ///
+    /// # Parameters
+    ///
+    /// - `_other` - Shaderpack to merge with.
+    pub fn merge_with_parent(&mut self, _other: &PipelineCreationInfo) -> Self {
+        unimplemented!()
+    }
+}
+
+/// A pass over the scene.
+///
+/// A pass has a few things:
+/// - What passes MUST be executed before this one.
+/// - What inputs this pass's shaders have:
+///      - What uniform buffers to use.
+///      - What vertex data to use.
+///      - Any textures that are needed.
+/// - What outputs this pass has:
+///      - Framebuffer attachments.
+///      - Write buffers.
+///
+/// The inputs and outputs of a pass must be resources declared in the shaderpack's `resources.json` file (or the
+/// default resources.json), or a resource that's internal to Nova. For example, Nova provides a UBO of uniforms that
+/// change per frame, a UBO for per-model data like the model matrix, and the virtual texture atlases. The default
+/// resources.json file sets up sixteen framebuffer color attachments for ping-pong buffers, a depth attachment,
+/// some shadow maps, etc.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenderPassCreationInfo {
+    /// The name of this render pass.
+    #[serde(default = "RenderPassCreationInfo::default_name")]
+    name: String,
+
+    /// The materials that MUST execute before this one.
+    dependencies: Vec<String>,
+
+    /// The textures that this pass will read from.
+    texture_inputs: Vec<String>,
+
+    /// The textures that this pass will write to.
+    texture_outputs: Vec<TextureAttachmentInfo>,
+
+    /// The depth texture this pass will write to.
+    depth_texture: Option<TextureAttachmentInfo>,
+
+    /// All the buffers that this renderpass reads from.
+    input_buffers: Vec<String>,
+
+    /// All the buffers that this renderpass writes to.
+    output_buffers: Vec<String>,
+}
+
+impl RenderPassCreationInfo {
+    fn default_name() -> String {
+        String::from("<NAME_MISSING>")
+    }
+}
+
+/// A single renderable material.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterialData {
+    /// The name of the material.
+    name: String,
+
+    /// The information needed for each renderpass the material is in.
+    passes: Vec<MaterialPass>,
+
+    /// Name of the geometry filter to use.
+    geometry_filter: String,
+}
+
+/// Holds all resources that are required by the shaderpack.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ShaderpackResourceData {
+    /// Specification for needed textures.
+    textures: Vec<TextureCreateInfo>,
+
+    /// Specification for needed samplers.
+    samplers: Vec<SamplerCreateInfo>,
+}
+
+/// Connects a [`VertexField`] with a semantic name.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VertexFieldData {
+    /// Name of the vertex field.
+    semantic_name: String,
+
+    /// Type of vertex data.
+    field: VertexField,
+}
+
+/// State of all the stencil operations.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StencilOpState {
+    /// Operation if stencil test fails.
+    #[serde(default = "StencilOpState::default_fail_op")]
+    fail_op: StencilOp,
+
+    /// Operation if stencil test passes.
+    #[serde(default = "StencilOpState::default_pass_op")]
+    pass_op: StencilOp,
+
+    /// Operation if depth test fails.
+    #[serde(default = "StencilOpState::default_depth_fail_op")]
+    depth_fail_op: StencilOp,
+
+    /// Comparison with the stencil buffer.
+    #[serde(default = "StencilOpState::default_compare_op")]
+    compare_op: CompareOp,
+
+    /// Stencil buffer comparison mask.
+    #[serde(default = "StencilOpState::default_compare_mask")]
+    compare_mask: u32,
+
+    /// Stencil buffer write mask.
+    #[serde(default = "StencilOpState::default_write_mask")]
+    write_mask: u32,
+}
+
+impl StencilOpState {
+    fn default_fail_op() -> StencilOp {
+        StencilOp::Keep
+    }
+    fn default_pass_op() -> StencilOp {
+        StencilOp::Keep
+    }
+    fn default_depth_fail_op() -> StencilOp {
+        StencilOp::Keep
+    }
+    fn default_compare_op() -> CompareOp {
+        CompareOp::Equal
+    }
+    fn default_compare_mask() -> u32 {
+        0
+    }
+    fn default_write_mask() -> u32 {
+        0
+    }
+}
+
+/// Shader source file as a compiled SPIR-V file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShaderSource {
+    /// Filename of the shader source file.
+    filename: PathBuf,
+
+    /// Compiled SPIR-V shader.
+    #[serde(skip)]
+    source: Vec<u32>,
+}
+
+/// A description of a texture that a render pass outputs to.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextureAttachmentInfo {
+    ///  The name of the texture.
+    name: String,
+
+    /// Pixel format of the texture.
+    #[serde(default = "TextureAttachmentInfo::default_pixel_format")]
+    pixel_format: PixelFormat,
+
+    /// Whether to clear the texture.
+    ///
+    /// If the texture is a depth buffer, it gets cleared to 1.
+    /// If the texture is a stencil buffer, it gets cleared to 0xFFFFFFFF.
+    /// If the texture is a color buffer, it gets cleared to (0, 0, 0, 0).
+    #[serde(default = "TextureAttachmentInfo::default_clear")]
+    clear: bool,
+}
+
+impl TextureAttachmentInfo {
+    fn default_pixel_format() -> PixelFormat {
+        PixelFormat::RGBA8
+    }
+    fn default_clear() -> bool {
+        false
+    }
+}
+
+/// The per-renderpass data for a material
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterialPass {
+    /// Name of the render pass.
+    name: String,
+
+    /// Name of the material itself.
+    ///
+    /// This is not populated by serde, this is populated by a post processing pass _after_ serde.
+    ///
+    /// TODO(cwfitzgerald): Which function does that?
+    #[serde(default)]
+    material_name: String,
+
+    /// Name of the pipeline.
+    pipeline: String,
+
+    /// All named bindings for this renderpass.
+    bindings: HashMap<String, String>,
+}
+
+/// Description of a texture
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextureCreateInfo {
+    /// The name of the texture.
+    ///
+    /// Nova implicitly defines a few textures for you to use:
+    /// - `ColorVirtualTexture`:
+    ///      - Virtual texture atlas that holds color textures.
+    ///      - Textures which have the exact name as requested by Minecraft are in this atlas.
+    ///      - Things without a color texture get a pure white texture.
+    ///      - Always has a format of `RGBA8`.
+    ///      - Can only be used as a pass's input.
+    /// - `NormalVirtualTexture`:
+    ///      - Virtual texture atlas that holds normal textures.
+    ///      - Textures which have `_n` after the name requested by Minecraft are in this atlas.
+    ///      - If no normal texture exists for a given object, a texture with RGBA of (0, 0, 1, 1) is used.
+    ///      - Always has a format of `RGBA8`.
+    ///      - Can only be used as a pass's input.
+    /// - `DataVirtualTexture`:
+    ///      - Virtual texture atlas that holds data textures.
+    ///      - Textures which have a `_s` after the name requested by Minecraft are in this atlas.
+    ///      - If no data texture exists for a given object, a texture with an RGBA of (0, 0, 0, 0) is used.
+    ///      - Always has a format of `RGBA8`.
+    ///      - Can only be used as a pass's input.
+    /// - `Lightmap`:
+    ///      - Lightmap, loaded from the current resourcepack.
+    ///      - Format of RGB8.
+    ///      - Can only be used as an input.
+    /// - `Backbuffer`:
+    ///      - The texture that gets presented to the screen.
+    ///      - Always has a format of RGB8.
+    ///      - Can only be used as a pass's output.
+    ///
+    /// If you use one of the virtual textures, then all fields except the binding are ignored.
+    ///
+    /// If you use `Backbuffer`, then all fields are ignored since the backbuffer is always bound to output location 0.
+    ///
+    /// TODO(cwfitzgerald): This can have a more elegant representation with an enum
+    name: String,
+
+    /// Texture format for the image.
+    ///
+    /// All members except the bindings are ignored if the texture is virtual. Everything is
+    /// ignored if the texture is the BackBuffer.
+    format: TextureFormat,
+}
+
+/// Defines a sampler to use for a texture.
+///
+/// At the time of writing I'm not sure how this is correlated with a texture, but all well.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SamplerCreateInfo {
+    /// String name of the sampler.
+    #[serde(default = "SamplerCreateInfo::default_name")]
+    name: String,
+
+    /// What kind of texture filter to use.
+    ///
+    /// texel_aa does something that I don't want to figure out right now. Bilinear is your regular bilinear filter,
+    /// and point is the point filter. Aniso isn't an option and I kinda hope it stays that way.
+    #[serde(default = "SamplerCreateInfo::default_filter")]
+    filter: TextureFilter,
+
+    /// How the texture should wrap at the edges.
+    #[serde(default = "SamplerCreateInfo::default_wrap_mode")]
+    wrap_mode: WrapMode,
+}
+
+impl SamplerCreateInfo {
+    fn default_name() -> String {
+        String::new()
+    }
+    fn default_filter() -> TextureFilter {
+        TextureFilter::Point
+    }
+    fn default_wrap_mode() -> WrapMode {
+        WrapMode::Clamp
+    }
+}
+
+/// The formatting information of a texture in memory.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextureFormat {
+    /// The format of the texture.
+    #[serde(default = "TextureFormat::default_pixel_format")]
+    pixel_format: PixelFormat,
+
+    /// How to interpret the dimensions of this texture.
+    #[serde(default = "TextureFormat::default_dimension_type")]
+    dimension_type: TextureDimensionType,
+
+    /// The width, in pixels, of the texture.
+    #[serde(default = "TextureFormat::default_width")]
+    width: f32,
+
+    /// The height, in pixels, of the texture.
+    #[serde(default = "TextureFormat::default_height")]
+    height: f32,
+}
+
+impl TextureFormat {
+    fn default_pixel_format() -> PixelFormat {
+        PixelFormat::RGBA8
+    }
+    fn default_dimension_type() -> TextureDimensionType {
+        TextureDimensionType::ScreenRelative
+    }
+    fn default_width() -> f32 {
+        0.0
+    }
+    fn default_height() -> f32 {
+        0.0
+    }
+
+    /// Returns the screen size in pixels.
+    ///
+    /// # Parameters
+    ///
+    /// - `screen_size` - Needed if the texture resolution is relative to the screen size
+    pub fn get_size_in_pixels(&self, screen_size: Vector2<f32>) -> Vector2<f32> {
+        let (width, height) = match self.dimension_type {
+            TextureDimensionType::ScreenRelative => (self.width * screen_size.x, self.height * screen_size.y),
+            TextureDimensionType::Absolute => (self.width, self.height),
+        };
+
+        Vector2::new(width.round(), height.round())
+    }
+}
+
+/// State of the fixed-function rasterizer.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum RasterizerState {
+    /// Enable blending for this material state.
+    Blending,
+
+    /// Render backfaces and cull frontfaces.
+    InvertCulling,
+
+    /// Don't cull backfaces or frontfaces.
+    DisableCulling,
+
+    /// Don't write to the depth buffer.
+    DisableDepthWrite,
+
+    /// Don't perform a depth test.
+    DisableDepthTest,
+
+    /// Perform the stencil test.
+    EnableStencilTest,
+
+    /// Write to the stencil buffer.
+    StencilWrite,
+
+    /// Don't write to the color buffer.
+    DisableColorWrite,
+
+    /// Enable alpha to coverage.
+    EnableAlphaToCoverage,
+
+    /// Don't write alpha.
+    DisableAlphaWrite,
+}
+
+/// Multisample Antialiasing mode.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum MSAASupport {
+    /// Enable MSAA.
+    MSAA,
+
+    /// Disable antialiasing.
+    None,
+}
+
+/// Primitive to interpret vertex buffer as.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum PrimitiveTopology {
+    /// Rasterize triangles.
+    Triangles,
+
+    /// Rasterize lines.
+    Lines,
+}
+
+/// How to blend the new image with the old image.
+///
+/// See [opengl wiki](https://www.khronos.org/opengl/wiki/Blending#Blend_Equations) for more info.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum BlendFactor {
+    /// 1 * color
+    One,
+
+    /// 0 * color
+    Zero,
+
+    /// Pull from source color.
+    SrcColor,
+
+    /// Pull from destination color.
+    DstColor,
+
+    /// 1 - src
+    OneMinusSrcColor,
+
+    /// 1 - dst
+    OneMinusDstColor,
+
+    /// Pull from source alpha.
+    SrcAlpha,
+
+    /// Pull from destination alpha.
+    DstAlpha,
+
+    /// 1 - srcA
+    OneMinusSrcAlpha,
+
+    /// 1 - dstA
+    OneMinusDstAlpha,
+}
+
+/// Comparator used for fixed function operations.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum CompareOp {
+    /// false
+    Never,
+
+    /// a < b
+    Less,
+
+    /// a <= b
+    LessEqual,
+
+    /// a > b
+    Greater,
+
+    /// a >= b
+    GreaterEqual,
+
+    /// a == b
+    Equal,
+
+    /// a != b
+    NotEqual,
+
+    /// true
+    Always,
+}
+
+/// Objects join a queue based on the type of transparency they need.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum RenderQueue {
+    /// Full alpha transparency.
+    Transparent,
+
+    /// No transparency.
+    Opaque,
+
+    /// Cutout transparency (full transparent or opaque).
+    Cutout,
+}
+
+/// Identifier for a type and data format for vertex data.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum VertexField {
+    /// The vertex position.
+    ///
+    /// 12 bytes
+    Position,
+
+    /// The vertex color.
+    ///
+    /// 4 bytes.
+    Color,
+
+    /// The UV coordinate of this object.
+    ///
+    /// Except not really, because Nova's virtual textures means that the UVs for a block or entity or whatever
+    /// could change on the fly, so this is kinda more of a preprocessor define that replaces the UV with a lookup
+    /// in the UV table.
+    ///
+    /// 8 bytes (might try 4).
+    UV0,
+
+    /// The UV coordinate in the lightmap texture.
+    ///
+    /// This is a real UV and it doesn't change for no good reason.
+    ///
+    /// 2 bytes.
+    UV1,
+
+    /// Vertex normal.
+    ///
+    /// 12 bytes.
+    Normal,
+
+    /// Vertex tangents.
+    ///
+    /// 12 bytes.
+    Tangent,
+
+    /// The texture coordinate of the middle of the quad.
+    ///
+    /// 8 bytes
+    MidTexCoord,
+
+    /// A uint32_t that's a unique identifier for the texture that this vertex uses.
+    ///
+    /// This is generated at runtime by Nova, so it may change a lot depending on what resourcepacks are loaded and
+    /// if they use CTM or random detail textures or whatever.
+    ///
+    /// 4 bytes.
+    VirtualTextureId,
+
+    /// Some information about the current block/entity/whatever.
+    ///
+    /// 12 bytes
+    McEntityId,
+}
+
+/// Which operation to determine the value of the stencil buffer after a write.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum StencilOp {
+    /// Do not change the stencil buffer.
+    Keep,
+
+    /// Set the stencil buffer to zero.
+    Zero,
+
+    /// Replace the stencil buffer with the current replacement value.
+    Replace,
+
+    /// Increments the stencil buffer value.
+    Incr,
+
+    /// Increments the stencil buffer value, wrapping around to zero on overflow.
+    IncrWrap,
+
+    /// Decrements the stencil buffer value.
+    Decr,
+
+    /// Decrements the stencil buffer value, wrapping around to 2^n-1 on underflow.
+    DecrWrap,
+
+    /// Bitwise invert the current stencil value.
+    Invert,
+}
+
+/// Layout of pixels in memory
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum PixelFormat {
+    /// R, G, B, and A channels, all taking up 8 bits integers each. 4 bytes.
+    RGBA8,
+
+    /// R, G, B, and A channels, all taking up 16 bits floats each. 8 bytes.
+    RGBA16F,
+
+    /// R, G, B, and A channels, all taking up 32 bits floats each. 16 bytes.
+    RGBA32F,
+
+    /// Depth channel only.
+    Depth,
+
+    /// Depth and stencil channel.
+    DepthStencil,
+}
+
+/// Filter to use when reading from texture.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum TextureFilter {
+    /// Bedrock features texel manipulation based AA.
+    TexelAA,
+
+    /// Bilinear filtering.
+    Bilinear,
+
+    /// Normal filtering.
+    Point,
+}
+
+/// Texture wrap mode.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum WrapMode {
+    /// Repeat the texture when out of UV bounds.
+    Repeat,
+
+    /// Clamp to the edge of the UV when out of UV bounds.
+    Clamp,
+}
+
+/// Frame of reference for texture dimensions.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum TextureDimensionType {
+    /// Dimensions are relative to the screen to allow screen space textures of the appropriate size.
+    ScreenRelative,
+
+    /// Dimensions are absolute.
+    Absolute,
+}
+
+/// Origin location of a texture
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum TextureLocation {
+    /// The texture is written to by a shader.
+    Dynamic,
+
+    /// The texture is loaded from the textures/ folder in the current shaderpack.
+    InUserPackage,
+
+    /// The texture is provided by Nova or by Minecraft.
+    InAppPackage,
+}

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -162,10 +162,7 @@ impl PipelineCreationInfo {
         RenderQueue::Opaque
     }
     fn default_vertex_shader() -> ShaderSource {
-        ShaderSource {
-            filename: PathBuf::from("<NAME_MISSING>"),
-            source: Vec::new(),
-        }
+        ShaderSource::Path(String::from("<NAME_MISSING>"))
     }
 
     /// Merge a shaderpack with a "parent" shaderpack. Unimplemented.
@@ -312,16 +309,24 @@ impl StencilOpState {
     }
 }
 
-/// Shader source file as a compiled SPIR-V file.
+/// Shader source file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum ShaderSource {
+    /// Uncompiled shader with path to source
+    Path(String),
+    /// Compiled SPIR-V shader
+    Compiled(CompiledShader),
+}
+
+/// A fully compiled shader
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ShaderSource {
+pub struct CompiledShader {
     /// Filename of the shader source file.
-    pub filename: PathBuf,
-
+    pub filename: String,
     /// Compiled SPIR-V shader.
-    #[serde(skip)]
-    pub source: Vec<u32>,
+    pub spirv: Vec<u32>,
 }
 
 /// A description of a texture that a render pass outputs to.

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -386,8 +386,7 @@ pub struct MaterialPass {
     /// Name of the material itself.
     ///
     /// This is not populated by serde, this is populated by a post processing pass _after_ serde.
-    ///
-    /// TODO(cwfitzgerald): Which function does that?
+    /// This happens in the function `material_postprocess`.
     #[serde(default)]
     pub material_name: String,
 

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -328,7 +328,7 @@ impl StencilOpState {
 }
 
 /// Shader source file.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum ShaderSource {
     /// Uncompiled shader with path to source
@@ -338,7 +338,7 @@ pub enum ShaderSource {
 }
 
 /// A fully compiled shader
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CompiledShader {
     /// Filename of the shader source file.

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -1,7 +1,6 @@
 use cgmath::Vector2;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 /// A fully parsed Nova Shaderpack
 #[derive(Debug, Clone)]

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -7,16 +7,16 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 pub struct ShaderpackData {
     /// The pipelines that this shaderpack specifies.
-    pipelines: Vec<PipelineCreationInfo>,
+    pub pipelines: Vec<PipelineCreationInfo>,
 
     /// The renderpasses that this shaderpack specifies, in submission order.
-    passes: Vec<RenderPassCreationInfo>,
+    pub passes: Vec<RenderPassCreationInfo>,
 
     /// The materials that this shaderpack specifies.
-    materials: Vec<MaterialData>,
+    pub materials: Vec<MaterialData>,
 
     /// The resources that this shaderpack specifies.
-    resources: ShaderpackResourceData,
+    pub resources: ShaderpackResourceData,
 }
 
 /// Information needed to create a pipeline
@@ -24,101 +24,101 @@ pub struct ShaderpackData {
 #[serde(rename_all = "camelCase")]
 pub struct PipelineCreationInfo {
     /// The name of this pipeline.
-    name: String,
+    pub name: String,
 
     /// The pipeline that this pipeline inherits from.
-    parent: Option<String>,
+    pub parent: Option<String>,
 
     /// The name of the pass that this pipeline belongs to.
-    pass: String,
+    pub pass: String,
 
     /// All of the symbols in the shader that are defined by this state.
-    defines: Vec<String>,
+    pub defines: Vec<String>,
 
     /// Defines the rasterizer state that's active for this pipeline.
-    states: Vec<RasterizerState>,
+    pub states: Vec<RasterizerState>,
 
     /// Sets up the vertex fields that Nova will bind to this pipeline.
-    vertex_fields: Vec<VertexFieldData>,
+    pub vertex_fields: Vec<VertexFieldData>,
 
     /// The stencil buffer operations to perform on the front faces.
-    front_face: Option<StencilOpState>,
+    pub front_face: Option<StencilOpState>,
 
     /// The stencil buffer operations to perform on the back faces.
-    back_face: Option<StencilOpState>,
+    pub back_face: Option<StencilOpState>,
 
     /// The material to use if this one's shaders can't be found.
-    fallback: Option<String>,
+    pub fallback: Option<String>,
 
     /// A bias to apply to the depth.
     #[serde(default = "PipelineCreationInfo::default_depth_bias")]
-    depth_bias: f32,
+    pub depth_bias: f32,
 
     /// The depth bias, scaled by slope I guess?
     #[serde(default = "PipelineCreationInfo::default_slope_scaled_depth_bias")]
-    slope_scaled_depth_bias: f32,
+    pub slope_scaled_depth_bias: f32,
 
     /// The reference value to use for the stencil test.
     #[serde(default = "PipelineCreationInfo::default_stencil_ref")]
-    stencil_ref: u32,
+    pub stencil_ref: u32,
 
     /// The mask to use when reading from the stencil buffer.
     #[serde(default = "PipelineCreationInfo::default_stencil_read_mask")]
-    stencil_read_mask: u32,
+    pub stencil_read_mask: u32,
 
     /// The mask to use when writing to the stencil buffer.
     #[serde(default = "PipelineCreationInfo::default_stencil_write_mask")]
-    stencil_write_mask: u32,
+    pub stencil_write_mask: u32,
 
     /// How to handle MSAA for this state.
     #[serde(default = "PipelineCreationInfo::default_msaa_support")]
-    msaa_support: MSAASupport,
+    pub msaa_support: MSAASupport,
 
     /// Decides how the vertices are rendered.
     #[serde(default = "PipelineCreationInfo::default_primitive_mode")]
-    primitive_mode: PrimitiveTopology,
+    pub primitive_mode: PrimitiveTopology,
 
     /// Where to get the blending factor for the source.
     #[serde(default = "PipelineCreationInfo::default_src_blend_factor")]
-    src_blend_factor: BlendFactor,
+    pub src_blend_factor: BlendFactor,
 
     /// Where to get the blending factor for the destination.
     #[serde(default = "PipelineCreationInfo::default_dst_blend_factor")]
-    dst_blend_factor: BlendFactor,
+    pub dst_blend_factor: BlendFactor,
 
     /// How to get the source alpha in a blend.
     #[serde(default = "PipelineCreationInfo::default_alpha_src")]
-    alpha_src: BlendFactor,
+    pub alpha_src: BlendFactor,
 
     /// How to get the destination alpha in a blend.
     #[serde(rename = "alphaDest")]
     #[serde(default = "PipelineCreationInfo::default_alpha_dst")]
-    alpha_dst: BlendFactor,
+    pub alpha_dst: BlendFactor,
 
     /// The function to use for the depth test.
     #[serde(default = "PipelineCreationInfo::default_depth_func")]
-    depth_func: CompareOp,
+    pub depth_func: CompareOp,
 
     /// The render queue that this pass belongs to.
     /// This may or may not be removed depending on what is actually needed by Nova.
     #[serde(default = "PipelineCreationInfo::default_render_queue")]
-    render_queue: RenderQueue,
+    pub render_queue: RenderQueue,
 
     /// Vertex shader to use.
     #[serde(default = "PipelineCreationInfo::default_vertex_shader")]
-    vertex_shader: ShaderSource,
+    pub vertex_shader: ShaderSource,
 
     /// Geometry shader to use.
-    geometry_shader: Option<ShaderSource>,
+    pub geometry_shader: Option<ShaderSource>,
 
     /// Tessellation Control shader to use.
-    tessellation_control_shader: Option<ShaderSource>,
+    pub tessellation_control_shader: Option<ShaderSource>,
 
     /// Tessellation Evaluation shader to use.
-    tessellation_evaluation_shader: Option<ShaderSource>,
+    pub tessellation_evaluation_shader: Option<ShaderSource>,
 
     /// Fragment shader to use.
-    fragment_shader: Option<ShaderSource>,
+    pub fragment_shader: Option<ShaderSource>,
 }
 
 impl PipelineCreationInfo {
@@ -200,25 +200,25 @@ impl PipelineCreationInfo {
 pub struct RenderPassCreationInfo {
     /// The name of this render pass.
     #[serde(default = "RenderPassCreationInfo::default_name")]
-    name: String,
+    pub name: String,
 
     /// The materials that MUST execute before this one.
-    dependencies: Vec<String>,
+    pub dependencies: Vec<String>,
 
     /// The textures that this pass will read from.
-    texture_inputs: Vec<String>,
+    pub texture_inputs: Vec<String>,
 
     /// The textures that this pass will write to.
-    texture_outputs: Vec<TextureAttachmentInfo>,
+    pub texture_outputs: Vec<TextureAttachmentInfo>,
 
     /// The depth texture this pass will write to.
-    depth_texture: Option<TextureAttachmentInfo>,
+    pub depth_texture: Option<TextureAttachmentInfo>,
 
     /// All the buffers that this renderpass reads from.
-    input_buffers: Vec<String>,
+    pub input_buffers: Vec<String>,
 
     /// All the buffers that this renderpass writes to.
-    output_buffers: Vec<String>,
+    pub output_buffers: Vec<String>,
 }
 
 impl RenderPassCreationInfo {
@@ -232,23 +232,23 @@ impl RenderPassCreationInfo {
 #[serde(rename_all = "camelCase")]
 pub struct MaterialData {
     /// The name of the material.
-    name: String,
+    pub name: String,
 
     /// The information needed for each renderpass the material is in.
-    passes: Vec<MaterialPass>,
+    pub passes: Vec<MaterialPass>,
 
     /// Name of the geometry filter to use.
-    geometry_filter: String,
+    pub geometry_filter: String,
 }
 
 /// Holds all resources that are required by the shaderpack.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ShaderpackResourceData {
     /// Specification for needed textures.
-    textures: Vec<TextureCreateInfo>,
+    pub textures: Vec<TextureCreateInfo>,
 
     /// Specification for needed samplers.
-    samplers: Vec<SamplerCreateInfo>,
+    pub samplers: Vec<SamplerCreateInfo>,
 }
 
 /// Connects a [`VertexField`] with a semantic name.
@@ -256,10 +256,10 @@ pub struct ShaderpackResourceData {
 #[serde(rename_all = "camelCase")]
 pub struct VertexFieldData {
     /// Name of the vertex field.
-    semantic_name: String,
+    pub semantic_name: String,
 
     /// Type of vertex data.
-    field: VertexField,
+    pub field: VertexField,
 }
 
 /// State of all the stencil operations.
@@ -268,27 +268,27 @@ pub struct VertexFieldData {
 pub struct StencilOpState {
     /// Operation if stencil test fails.
     #[serde(default = "StencilOpState::default_fail_op")]
-    fail_op: StencilOp,
+    pub fail_op: StencilOp,
 
     /// Operation if stencil test passes.
     #[serde(default = "StencilOpState::default_pass_op")]
-    pass_op: StencilOp,
+    pub pass_op: StencilOp,
 
     /// Operation if depth test fails.
     #[serde(default = "StencilOpState::default_depth_fail_op")]
-    depth_fail_op: StencilOp,
+    pub depth_fail_op: StencilOp,
 
     /// Comparison with the stencil buffer.
     #[serde(default = "StencilOpState::default_compare_op")]
-    compare_op: CompareOp,
+    pub compare_op: CompareOp,
 
     /// Stencil buffer comparison mask.
     #[serde(default = "StencilOpState::default_compare_mask")]
-    compare_mask: u32,
+    pub compare_mask: u32,
 
     /// Stencil buffer write mask.
     #[serde(default = "StencilOpState::default_write_mask")]
-    write_mask: u32,
+    pub write_mask: u32,
 }
 
 impl StencilOpState {
@@ -317,11 +317,11 @@ impl StencilOpState {
 #[serde(rename_all = "camelCase")]
 pub struct ShaderSource {
     /// Filename of the shader source file.
-    filename: PathBuf,
+    pub filename: PathBuf,
 
     /// Compiled SPIR-V shader.
     #[serde(skip)]
-    source: Vec<u32>,
+    pub source: Vec<u32>,
 }
 
 /// A description of a texture that a render pass outputs to.
@@ -329,11 +329,11 @@ pub struct ShaderSource {
 #[serde(rename_all = "camelCase")]
 pub struct TextureAttachmentInfo {
     ///  The name of the texture.
-    name: String,
+    pub name: String,
 
     /// Pixel format of the texture.
     #[serde(default = "TextureAttachmentInfo::default_pixel_format")]
-    pixel_format: PixelFormat,
+    pub pixel_format: PixelFormat,
 
     /// Whether to clear the texture.
     ///
@@ -341,7 +341,7 @@ pub struct TextureAttachmentInfo {
     /// If the texture is a stencil buffer, it gets cleared to 0xFFFFFFFF.
     /// If the texture is a color buffer, it gets cleared to (0, 0, 0, 0).
     #[serde(default = "TextureAttachmentInfo::default_clear")]
-    clear: bool,
+    pub clear: bool,
 }
 
 impl TextureAttachmentInfo {
@@ -358,7 +358,7 @@ impl TextureAttachmentInfo {
 #[serde(rename_all = "camelCase")]
 pub struct MaterialPass {
     /// Name of the render pass.
-    name: String,
+    pub name: String,
 
     /// Name of the material itself.
     ///
@@ -366,13 +366,13 @@ pub struct MaterialPass {
     ///
     /// TODO(cwfitzgerald): Which function does that?
     #[serde(default)]
-    material_name: String,
+    pub material_name: String,
 
     /// Name of the pipeline.
-    pipeline: String,
+    pub pipeline: String,
 
     /// All named bindings for this renderpass.
-    bindings: HashMap<String, String>,
+    pub bindings: HashMap<String, String>,
 }
 
 /// Description of a texture
@@ -414,13 +414,13 @@ pub struct TextureCreateInfo {
     /// If you use `Backbuffer`, then all fields are ignored since the backbuffer is always bound to output location 0.
     ///
     /// TODO(cwfitzgerald): This can have a more elegant representation with an enum
-    name: String,
+    pub name: String,
 
     /// Texture format for the image.
     ///
     /// All members except the bindings are ignored if the texture is virtual. Everything is
     /// ignored if the texture is the BackBuffer.
-    format: TextureFormat,
+    pub format: TextureFormat,
 }
 
 /// Defines a sampler to use for a texture.
@@ -431,18 +431,18 @@ pub struct TextureCreateInfo {
 pub struct SamplerCreateInfo {
     /// String name of the sampler.
     #[serde(default = "SamplerCreateInfo::default_name")]
-    name: String,
+    pub name: String,
 
     /// What kind of texture filter to use.
     ///
     /// texel_aa does something that I don't want to figure out right now. Bilinear is your regular bilinear filter,
     /// and point is the point filter. Aniso isn't an option and I kinda hope it stays that way.
     #[serde(default = "SamplerCreateInfo::default_filter")]
-    filter: TextureFilter,
+    pub filter: TextureFilter,
 
     /// How the texture should wrap at the edges.
     #[serde(default = "SamplerCreateInfo::default_wrap_mode")]
-    wrap_mode: WrapMode,
+    pub wrap_mode: WrapMode,
 }
 
 impl SamplerCreateInfo {
@@ -463,19 +463,19 @@ impl SamplerCreateInfo {
 pub struct TextureFormat {
     /// The format of the texture.
     #[serde(default = "TextureFormat::default_pixel_format")]
-    pixel_format: PixelFormat,
+    pub pixel_format: PixelFormat,
 
     /// How to interpret the dimensions of this texture.
     #[serde(default = "TextureFormat::default_dimension_type")]
-    dimension_type: TextureDimensionType,
+    pub dimension_type: TextureDimensionType,
 
     /// The width, in pixels, of the texture.
     #[serde(default = "TextureFormat::default_width")]
-    width: f32,
+    pub width: f32,
 
     /// The height, in pixels, of the texture.
     #[serde(default = "TextureFormat::default_height")]
-    height: f32,
+    pub height: f32,
 }
 
 impl TextureFormat {

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -416,7 +416,7 @@ pub struct MaterialPass {
     /// Name of the material itself.
     ///
     /// This is not populated by serde, this is populated by a post processing pass _after_ serde.
-    /// This happens in the function `material_postprocess`.
+    /// This happens in the function `shaderpack::set_material_pass_material_name`.
     #[serde(default)]
     pub material_name: String,
 

--- a/src/shaderpack/structs.rs
+++ b/src/shaderpack/structs.rs
@@ -514,7 +514,6 @@ impl TextureFormat {
 
 /// State of the fixed-function rasterizer.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum RasterizerState {
     /// Enable blending for this material state.
     Blending,
@@ -549,7 +548,6 @@ pub enum RasterizerState {
 
 /// Multisample Antialiasing mode.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum MSAASupport {
     /// Enable MSAA.
     MSAA,
@@ -560,7 +558,6 @@ pub enum MSAASupport {
 
 /// Primitive to interpret vertex buffer as.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum PrimitiveTopology {
     /// Rasterize triangles.
     Triangles,
@@ -573,7 +570,6 @@ pub enum PrimitiveTopology {
 ///
 /// See [opengl wiki](https://www.khronos.org/opengl/wiki/Blending#Blend_Equations) for more info.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum BlendFactor {
     /// 1 * color
     One,
@@ -608,7 +604,6 @@ pub enum BlendFactor {
 
 /// Comparator used for fixed function operations.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum CompareOp {
     /// false
     Never,
@@ -637,7 +632,6 @@ pub enum CompareOp {
 
 /// Objects join a queue based on the type of transparency they need.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum RenderQueue {
     /// Full alpha transparency.
     Transparent,
@@ -651,7 +645,6 @@ pub enum RenderQueue {
 
 /// Identifier for a type and data format for vertex data.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum VertexField {
     /// The vertex position.
     ///
@@ -710,7 +703,6 @@ pub enum VertexField {
 
 /// Which operation to determine the value of the stencil buffer after a write.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum StencilOp {
     /// Do not change the stencil buffer.
     Keep,
@@ -739,7 +731,6 @@ pub enum StencilOp {
 
 /// Layout of pixels in memory
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum PixelFormat {
     /// R, G, B, and A channels, all taking up 8 bits integers each. 4 bytes.
     RGBA8,
@@ -759,7 +750,6 @@ pub enum PixelFormat {
 
 /// Filter to use when reading from texture.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum TextureFilter {
     /// Bedrock features texel manipulation based AA.
     TexelAA,
@@ -773,7 +763,6 @@ pub enum TextureFilter {
 
 /// Texture wrap mode.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum WrapMode {
     /// Repeat the texture when out of UV bounds.
     Repeat,
@@ -784,7 +773,6 @@ pub enum WrapMode {
 
 /// Frame of reference for texture dimensions.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum TextureDimensionType {
     /// Dimensions are relative to the screen to allow screen space textures of the appropriate size.
     ScreenRelative,
@@ -795,7 +783,6 @@ pub enum TextureDimensionType {
 
 /// Origin location of a texture
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(untagged)]
 pub enum TextureLocation {
     /// The texture is written to by a shader.
     Dynamic,

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.mat
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.mat
@@ -1,0 +1,13 @@
+{
+    "name": "final",
+    "filter": "geometry_type::fullscreen_quad",
+    "passes": [
+        {
+            "name": "main",
+            "pipeline": "Final",
+            "bindings": {
+                "per_model_uniforms": "NovaModelMatrixBuffer"
+            }
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.pipeline
@@ -1,0 +1,21 @@
+{
+    "name": "Final",
+    "pass": "Final",
+    "states": [
+        "DisableAlphaWrite",
+        "DisableDepthWrite",
+        "DisableDepthTest"
+    ],
+    "vertexShader": "shaders/textured_unlit",
+    "fragmentShader": "shaders/image_passthrough",
+    "vertexFields": [
+        {
+            "name": "position_in",
+            "field": "Position"
+        },
+        {
+            "name": "uv_in",
+            "field": "UV0"
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/final.pipeline
@@ -6,8 +6,8 @@
         "DisableDepthWrite",
         "DisableDepthTest"
     ],
-    "vertexShader": "shaders/textured_unlit",
-    "fragmentShader": "shaders/image_passthrough",
+    "vertexShader": "shaders/textured_unlit.vert",
+    "fragmentShader": "shaders/image_passthrough.frag",
     "vertexFields": [
         {
             "name": "position_in",

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.mat
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.mat
@@ -1,0 +1,13 @@
+{
+    "name": "gbuffers_terrain",
+    "filter": "geometry_type::block AND not_transparent",
+    "passes": [
+        {
+            "name": "main",
+            "pipeline": "gbuffers_terrain",
+            "bindings": {
+                "per_model_uniforms": "NovaModelMatrixBuffer"
+            }
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.pipeline
@@ -1,0 +1,47 @@
+{
+    "name": "gbuffers_terrain",
+    "pass": "Forward",
+    "states": [
+        "DisableAlphaWrite"
+    ],
+    "vertexShader": "shaders/gbuffers_terrain",
+    "fragmentShader": "shaders/gbuffers_terrain",
+    "vertexFields": [
+        {
+            "name": "position_in",
+            "field": "Position"
+        },
+        {
+            "name": "color_in",
+            "field": "Color"
+        },
+        {
+            "name": "uv_in",
+            "field": "UV0"
+        },
+        {
+            "name": "lightmap_uv_in",
+            "field": "UV1"
+        },
+        {
+            "name": "normal_in",
+            "field": "Normal"
+        },
+        {
+            "name": "tangent_in",
+            "field": "Tangent"
+        },
+        {
+            "name": "mix_tex_coord_in",
+            "field": "MidTexCoord"
+        },
+        {
+            "name": "virtual_texture_id_in",
+            "field": "VirtualTextureId"
+        },
+        {
+            "name": "mc_entity_id_in",
+            "field": "McEntityId"
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gbuffers_terrain.pipeline
@@ -4,8 +4,8 @@
     "states": [
         "DisableAlphaWrite"
     ],
-    "vertexShader": "shaders/gbuffers_terrain",
-    "fragmentShader": "shaders/gbuffers_terrain",
+    "vertexShader": "shaders/gbuffers_terrain.vert",
+    "fragmentShader": "shaders/gbuffers_terrain.frag",
     "vertexFields": [
         {
             "name": "position_in",

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.mat
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.mat
@@ -1,0 +1,13 @@
+{
+    "name": "gui",
+    "filter": "geometry_type::gui",
+    "passes": [
+        {
+            "name": "main",
+            "pipeline": "gui",
+            "bindings": {
+                "per_model_uniforms": "NovaModelMatrixBuffer"
+            }
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.pipeline
@@ -5,8 +5,8 @@
     "states": [
         "DisableAlphaWrite"
     ],
-    "vertexShader": "shaders/gui",
-    "fragmentShader": "shaders/gui",
+    "vertexShader": "shaders/gui.vert",
+    "fragmentShader": "shaders/gui.frag",
     "vertexFields": [
         {
             "name": "position_in",

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.pipeline
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui.pipeline
@@ -1,0 +1,28 @@
+{
+    "name": "gui",
+    "pass": "Forward",
+    "depthFunc": "LessEqual",
+    "states": [
+        "DisableAlphaWrite"
+    ],
+    "vertexShader": "shaders/gui",
+    "fragmentShader": "shaders/gui",
+    "vertexFields": [
+        {
+            "name": "position_in",
+            "field": "Position"
+        },
+        {
+            "name": "uv_in",
+            "field": "UV0"
+        },
+        {
+            "name": "color_in",
+            "field": "Color"
+        },
+        {
+            "name": "virtual_texture_id_in",
+            "field": "VirtualTextureId"
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui_background.mat
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui_background.mat
@@ -1,0 +1,13 @@
+{
+    "name": "gui_background",
+    "filter": "geometry_type::gui_background",
+    "passes": [
+        {
+            "name": "main",
+            "pipeline": "gui",
+            "bindings": {
+                "per_model_uniforms": "NovaModelMatrixBuffer"
+            }
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui_text.mat
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/materials/gui_text.mat
@@ -1,0 +1,13 @@
+{
+    "name": "gui_text",
+    "filter": "geometry_type::text",
+    "passes": [
+        {
+            "name": "main",
+            "pipeline": "gui",
+            "bindings": {
+                "per_model_uniforms": "NovaModelMatrixBuffer"
+            }
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/passes.json
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/passes.json
@@ -1,0 +1,29 @@
+[
+    {
+        "name": "Forward",
+        "textureOutputs": [
+            {
+                "name": "LitWorld",
+                "clear": true
+            }
+        ],
+        "depthTexture": {
+            "name": "DepthBuffer",
+            "clear": true
+        },
+        "bufferInputs": [
+            "NovaMegaMesh_Vertices",
+            "NovaMegaMesh_Indices"
+        ]
+    }, 
+    {
+        "name": "Final",
+        "textureInputs": ["LitWorld"],
+        "textureOutputs": [
+            {
+                "name": "Backbuffer",
+                "clear": false
+            }
+        ]
+    }
+]

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/resources.json
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/resources.json
@@ -1,0 +1,29 @@
+{
+    "textures": [
+        {
+            "name": "LitWorld",
+            "format": {
+                "pixelFormat": "RGBA8",
+                "dimensionType": "ScreenRelative",
+                "width": 1,
+                "height": 1
+            }
+        },
+        {
+            "name": "DepthBuffer",
+            "format": {
+                "pixelFormat": "Depth",
+                "dimensionType": "ScreenRelative",
+                "width": 1,
+                "height": 1
+            }
+        }
+    ],
+    "samplers": [
+        {
+            "name": "Point",
+            "filter": "Point",
+            "wrapMode": "Clamp"
+        }
+    ]
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_terrain.frag
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_terrain.frag
@@ -1,0 +1,81 @@
+#version 460
+
+// layout(set = 2, binding = 0) uniform sampler2D colortex;
+// layout(set = 2, binding = 3) uniform sampler2D lightmap;
+
+/*
+layout(set = 1, binding = 0) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(location = 0) in vec2 uv;
+layout(location = 1) in vec4 color;
+layout(location = 2) in vec2 lightmap_uv;
+layout(location = 3) in vec3 normal;
+
+layout(location = 0) out vec4 color_out;
+
+void main() {
+
+    /*
+    if(textureSize(colortex, 0).x > 0) {
+        vec4 tex_sample = texture(colortex, uv);
+        if(tex_sample.a < 0.5) {
+            discard;
+        }
+        color_out = tex_sample;
+    } else {
+        color_out = vec4(1, 0, 1, 1);
+    }
+
+    color_out.rgb *= texture(lightmap, lightmap_uv).rgb * color.rgb;
+    */
+    color_out = vec4(1, 0, 1, 1);
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_terrain.vert
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_terrain.vert
@@ -1,0 +1,78 @@
+#version 460
+
+layout(location = 0) in vec3 position_in;
+layout(location = 2) in vec2 uv_in;
+layout(location = 3) in vec2 lightmap_uv_in;
+layout(location = 4) in vec3 normal_in;
+layout(location = 1) in vec4 color_in;
+
+/*
+layout(set = 1, binding = 0) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(set = 0, binding = 0) readonly buffer per_model_uniforms {
+    mat4 modelMatrices[];
+};
+
+layout(location = 0) out vec2 uv;
+layout(location = 1) out vec4 color;
+layout(location = 2) out vec2 lightmap_uv;
+layout(location = 3) out vec3 normal;
+
+void main() {
+    int model_matrix_index = gl_InstanceIndex - gl_BaseInstance;
+	gl_Position = /*gbufferProjection * gbufferModelView * gbufferModel */ modelMatrices[model_matrix_index] * vec4(position_in, 1.0f);
+
+	uv = uv_in;
+ 	color = color_in;
+ 	lightmap_uv = (lightmap_uv_in + 0.5) / 256;
+ 	normal = normal_in;
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_water.frag
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_water.frag
@@ -1,0 +1,69 @@
+#version 460
+
+layout(binding = 0) uniform sampler2D colortex;
+
+/*
+layout(std140) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(location = 0) in vec2 uv;
+layout(location = 1) in vec4 color;
+
+layout(location = 0) out vec4 color_out;
+
+void main() {
+    if(textureSize(colortex, 0).x > 0) {
+        vec4 tex_sample = texture(colortex, uv);
+        color_out = tex_sample;
+    } else {
+        color_out = vec4(1, 0, 1, 0.5);
+    }
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_water.vert
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gbuffers_water.vert
@@ -1,0 +1,70 @@
+#version 450
+
+layout(location = 0) in vec3 position_in;
+layout(location = 2) in vec2 uv_in;
+layout(location = 3) in vec2 lightmap_uv_in;
+layout(location = 4) in vec3 normal_in;
+
+layout(std140) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+
+layout(std140) readonly buffer per_model_uniforms {
+    mat4 modelMatrices[];
+};
+
+layout(location = 0) out vec2 uv;
+layout(location = 1) out vec4 color;
+
+void main() {
+	gl_Position = gbufferProjection * gbufferModelView * gbufferModel * vec4(position_in, 1.0f);
+
+	uv = uv_in;
+	color = vec4(1);
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gui.frag
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gui.frag
@@ -1,0 +1,75 @@
+#version 460
+
+// layout(set = 2, binding = 0) uniform sampler2D colortex;
+
+/*
+layout(set = 1, binding = 0) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(location = 0) in vec2 uv;
+layout(location = 1) in vec4 color;
+
+layout(location = 0) out vec4 color_out;
+
+void main() {
+    /*
+    if(textureSize(colortex, 0).x > 0) {
+        vec4 tex_sample = texture(colortex, mod(uv,1.0));
+        if(tex_sample.a < 0.01) {
+            discard;
+        }
+        color_out = tex_sample * color;
+    } else {
+        color_out = vec4(1, 0, 1, 1);
+    }
+    */
+    color_out = vec4(1, 0, 1, 1);
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gui.vert
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/gui.vert
@@ -1,0 +1,71 @@
+#version 460
+
+layout(location = 0) in vec3 position_in;
+layout(location = 1) in vec2 uv_in;
+layout(location = 2) in vec4 color_in;
+
+/*
+layout(set = 1, binding = 0) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(set = 0, binding = 0) readonly buffer per_model_uniforms {
+    mat4 modelMatrices[];
+};
+
+layout(location = 0) out vec2 uv;
+layout(location = 1) out vec4 color;
+
+void main() {
+    gl_Position = /*gbufferProjection * gbufferModelView * gbufferModel */ vec4(position_in, 1.0f);
+
+    uv = uv_in;
+    color = color_in;
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/image_passthrough.frag
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/image_passthrough.frag
@@ -1,0 +1,11 @@
+#version 450
+
+//layout(set = 2, location = 0, binding = 0) uniform sampler2D tex;
+
+layout(location = 0) in vec2 uv;
+
+layout(location = 0) out vec4 color;
+
+void main() {
+    color = vec4(1, 0, 1, 1); // texture(tex, uv);
+}

--- a/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/textured_unlit.vert
+++ b/tests/data/shaderpacks/nova/DefaultShaderpack/shaders/textured_unlit.vert
@@ -1,0 +1,68 @@
+#version 460
+
+layout(location = 0) in vec3 position_in;
+layout(location = 1) in vec2 uv_in;
+
+/*
+layout(set = 1, binding = 0) uniform per_frame_uniforms {
+    mat4 gbufferModelView;
+    mat4 gbufferModelViewInverse;
+    mat4 gbufferPreviousModelView;
+    mat4 gbufferProjection;
+    mat4 gbufferProjectionInverse;
+    mat4 gbufferPreviousProjection;
+    mat4 shadowProjection;
+    mat4 shadowProjectionInverse;
+    mat4 shadowModelView;
+    mat4 shadowModelViewInverse;
+    vec4 entityColor;
+    vec3 fogColor;
+    vec3 skyColor;
+    vec3 sunPosition;
+    vec3 moonPosition;
+    vec3 shadowLightPosition;
+    vec3 upPosition;
+    vec3 cameraPosition;
+    vec3 previousCameraPosition;
+    ivec2 eyeBrightness;
+    ivec2 eyeBrightnessSmooth;
+    ivec2 terrainTextureSize;
+    ivec2 atlasSize;
+    int heldItemId;
+    int heldBlockLightValue;
+    int heldItemId2;
+    int heldBlockLightValue2;
+    int fogMode;
+    int worldTime;
+    int moonPhase;
+    int terrainIconSize;
+    int isEyeInWater;
+    int hideGUI;
+    int entityId;
+    int blockEntityId;
+    float frameTimeCounter;
+    float sunAngle;
+    float shadowAngle;
+    float rainStrength;
+    float aspectRatio;
+    float viewWidth;
+    float viewHeight;
+    float near;
+    float far;
+    float wetness;
+    float eyeAltitude;
+    float centerDepthSmooth;
+};
+*/
+
+layout(set = 0, binding = 0) readonly buffer per_model_uniforms{
+    mat4 modelMatrices[];
+};
+
+layout(location = 0) out vec2 uv;
+
+void main() {
+    gl_Position = /*gbufferProjection * gbufferModelView * gbufferModel */ vec4(position_in, 1);
+
+    uv = uv_in;
+}

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -1,4 +1,7 @@
-use futures::executor::{block_on, ThreadPoolBuilder};
+#![allow(clippy::cognitive_complexity)]
+#![allow(clippy::float_cmp)]
+
+use futures::executor::ThreadPoolBuilder;
 use nova_rs::shaderpack::*;
 use std::path::PathBuf;
 

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -1,13 +1,314 @@
 use futures::executor::block_on;
-use nova_rs::shaderpack;
-use nova_rs::shaderpack::{load_nova_shaderpack, ShaderpackLoadingFailure};
+use nova_rs::shaderpack::*;
 use std::path::PathBuf;
 
 #[test]
 fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
-    let parsed = block_on(load_nova_shaderpack(PathBuf::from(
+    let mut parsed: ShaderpackData = block_on(load_nova_shaderpack(PathBuf::from(
         "tests/data/shaderpacks/nova/DefaultShaderpack",
     )))?;
+
+    // Renderpass checking
+    {
+        let passes = &parsed.passes;
+        assert_eq!(passes.len(), 2);
+
+        ///// ////// /////
+        ///// Pass 1 /////
+        ///// ////// /////
+        let pass = &passes[0];
+        assert_eq!(pass.name, "Forward");
+
+        // Texture outputs
+        assert_eq!(pass.texture_outputs.len(), 1);
+        let texture_output = &pass.texture_outputs[0];
+        assert_eq!(texture_output.name, "LitWorld");
+        assert_eq!(texture_output.clear, true);
+
+        // Depth Texture
+        assert_eq!(pass.depth_texture.is_some(), true);
+        let depth_texture = pass.depth_texture.as_ref().unwrap();
+        assert_eq!(depth_texture.name, "DepthBuffer");
+        assert_eq!(depth_texture.clear, true);
+        assert_eq!(depth_texture.pixel_format, PixelFormat::RGBA8);
+
+        // Buffer Inputs
+        assert_eq!(pass.input_buffers.len(), 2);
+        let buffer_input = &pass.input_buffers[0];
+        assert_eq!(buffer_input, "NovaMegaMesh_Vertices");
+        let buffer_input = &pass.input_buffers[1];
+        assert_eq!(buffer_input, "NovaMegaMesh_Indices");
+
+        ///// ////// /////
+        ///// Pass 2 /////
+        ///// ////// /////
+        let pass = &passes[1];
+        assert_eq!(pass.name, "Final");
+
+        // Texture inputs
+        assert_eq!(pass.texture_inputs.len(), 1);
+        let texture_input = &pass.texture_inputs[0];
+        assert_eq!(texture_input, "LitWorld");
+
+        // Texture outputs
+        assert_eq!(pass.texture_outputs.len(), 1);
+        let texture_output = &pass.texture_outputs[0];
+        assert_eq!(texture_output.name, "Backbuffer");
+        assert_eq!(texture_output.clear, false);
+    }
+
+    // Resources
+    {
+        let resources = &parsed.resources;
+
+        assert_eq!(resources.textures.len(), 2);
+
+        ///// ///////// /////
+        ///// Texture 1 /////
+        ///// ///////// /////
+        let texture = &resources.textures[0];
+        assert_eq!(texture.name, "LitWorld");
+        let format = &texture.format;
+        assert_eq!(format.pixel_format, PixelFormat::RGBA8);
+        assert_eq!(format.dimension_type, TextureDimensionType::ScreenRelative);
+        assert_eq!(format.width, 1.0_f32);
+        assert_eq!(format.height, 1.0_f32);
+
+        ///// ///////// /////
+        ///// Texture 2 /////
+        ///// ///////// /////
+        let texture = &resources.textures[1];
+        assert_eq!(texture.name, "DepthBuffer");
+        let format = &texture.format;
+        assert_eq!(format.pixel_format, PixelFormat::Depth);
+        assert_eq!(format.dimension_type, TextureDimensionType::ScreenRelative);
+        assert_eq!(format.width, 1.0_f32);
+        assert_eq!(format.height, 1.0_f32);
+
+        assert_eq!(resources.samplers.len(), 1);
+
+        ///// ///////// /////
+        ///// Sampler 1 /////
+        ///// ///////// /////
+        let sampler = &resources.samplers[0];
+        assert_eq!(sampler.name, "Point");
+        assert_eq!(sampler.filter, TextureFilter::Point);
+        assert_eq!(sampler.wrap_mode, WrapMode::Clamp);
+    }
+
+    // Materials
+    {
+        assert_eq!(parsed.materials.len(), 5);
+
+        parsed.materials.sort_by_cached_key(|m| m.name.clone());
+
+        ///// ///////// /////
+        ///// Final.mat /////
+        ///// ///////// /////
+        let material = &parsed.materials[0];
+        assert_eq!(material.name, "final");
+        assert_eq!(material.geometry_filter, "geometry_type::fullscreen_quad");
+
+        assert_eq!(material.passes.len(), 1);
+        let pass = &material.passes[0];
+        assert_eq!(pass.name, "main");
+        assert_eq!(pass.pipeline, "Final");
+
+        assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
+        let binding = &pass.bindings["per_model_uniforms"];
+        assert_eq!(binding, "NovaModelMatrixBuffer");
+
+        ///// //////////////////// /////
+        ///// gbuffers_terrain.mat /////
+        ///// //////////////////// /////
+        let material = &parsed.materials[1];
+        assert_eq!(material.name, "gbuffers_terrain");
+        assert_eq!(material.geometry_filter, "geometry_type::block AND not_transparent");
+
+        assert_eq!(material.passes.len(), 1);
+        let pass = &material.passes[0];
+        assert_eq!(pass.name, "main");
+        assert_eq!(pass.pipeline, "gbuffers_terrain");
+
+        assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
+        let binding = &pass.bindings["per_model_uniforms"];
+        assert_eq!(binding, "NovaModelMatrixBuffer");
+
+        ///// /////// /////
+        ///// gui.mat /////
+        ///// /////// /////
+        let material = &parsed.materials[2];
+        assert_eq!(material.name, "gui");
+        assert_eq!(material.geometry_filter, "geometry_type::gui");
+
+        assert_eq!(material.passes.len(), 1);
+        let pass = &material.passes[0];
+        assert_eq!(pass.name, "main");
+        assert_eq!(pass.pipeline, "gui");
+
+        assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
+        let binding = &pass.bindings["per_model_uniforms"];
+        assert_eq!(binding, "NovaModelMatrixBuffer");
+
+        ///// ////////////////// /////
+        ///// gui_background.mat /////
+        ///// ////////////////// /////
+        let material = &parsed.materials[3];
+        assert_eq!(material.name, "gui_background");
+        assert_eq!(material.geometry_filter, "geometry_type::gui_background");
+
+        assert_eq!(material.passes.len(), 1);
+        let pass = &material.passes[0];
+        assert_eq!(pass.name, "main");
+        assert_eq!(pass.pipeline, "gui");
+
+        assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
+        let binding = &pass.bindings["per_model_uniforms"];
+        assert_eq!(binding, "NovaModelMatrixBuffer");
+
+        ///// //////////// /////
+        ///// gui_text.mat /////
+        ///// //////////// /////
+        let material = &parsed.materials[4];
+        assert_eq!(material.name, "gui_text");
+        assert_eq!(material.geometry_filter, "geometry_type::text");
+
+        assert_eq!(material.passes.len(), 1);
+        let pass = &material.passes[0];
+        assert_eq!(pass.name, "main");
+        assert_eq!(pass.pipeline, "gui");
+
+        assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
+        let binding = &pass.bindings["per_model_uniforms"];
+        assert_eq!(binding, "NovaModelMatrixBuffer");
+    }
+
+    // Pipelines
+    {
+        assert_eq!(parsed.pipelines.len(), 3);
+
+        parsed.pipelines.sort_by_cached_key(|m| m.name.clone());
+
+        ///// ////////////// /////
+        ///// final.pipeline /////
+        ///// ////////////// /////
+        let pipeline = &parsed.pipelines[0];
+        assert_eq!(pipeline.name, "Final");
+        assert_eq!(pipeline.pass, "Final");
+
+        assert_eq!(pipeline.states.len(), 3);
+        assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
+        assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthWrite), true);
+        assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthTest), true);
+
+        assert_eq!(
+            pipeline.vertex_shader,
+            ShaderSource::Path(String::from("shaders/textured_unlit"))
+        );
+        assert_eq!(
+            pipeline.fragment_shader,
+            Some(ShaderSource::Path(String::from("shaders/image_passthrough")))
+        );
+
+        assert_eq!(pipeline.vertex_fields.len(), 2);
+        let vertex_field = &pipeline.vertex_fields[0];
+        assert_eq!(vertex_field.semantic_name, "position_in");
+        assert_eq!(vertex_field.field, VertexField::Position);
+
+        let vertex_field = &pipeline.vertex_fields[1];
+        assert_eq!(vertex_field.semantic_name, "uv_in");
+        assert_eq!(vertex_field.field, VertexField::UV0);
+
+        ///// ///////////////////////// /////
+        ///// gbuffers_terrain.pipeline /////
+        ///// ///////////////////////// /////
+        let pipeline = &parsed.pipelines[1];
+        assert_eq!(pipeline.name, "gbuffers_terrain");
+        assert_eq!(pipeline.pass, "Forward");
+
+        assert_eq!(pipeline.states.len(), 1);
+        assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
+
+        assert_eq!(
+            pipeline.vertex_shader,
+            ShaderSource::Path(String::from("shaders/gbuffers_terrain"))
+        );
+        assert_eq!(
+            pipeline.fragment_shader,
+            Some(ShaderSource::Path(String::from("shaders/gbuffers_terrain")))
+        );
+
+        assert_eq!(pipeline.vertex_fields.len(), 9);
+        let vertex_field = &pipeline.vertex_fields[0];
+        assert_eq!(vertex_field.semantic_name, "position_in");
+        assert_eq!(vertex_field.field, VertexField::Position);
+
+        let vertex_field = &pipeline.vertex_fields[1];
+        assert_eq!(vertex_field.semantic_name, "color_in");
+        assert_eq!(vertex_field.field, VertexField::Color);
+
+        let vertex_field = &pipeline.vertex_fields[2];
+        assert_eq!(vertex_field.semantic_name, "uv_in");
+        assert_eq!(vertex_field.field, VertexField::UV0);
+
+        let vertex_field = &pipeline.vertex_fields[3];
+        assert_eq!(vertex_field.semantic_name, "lightmap_uv_in");
+        assert_eq!(vertex_field.field, VertexField::UV1);
+
+        let vertex_field = &pipeline.vertex_fields[4];
+        assert_eq!(vertex_field.semantic_name, "normal_in");
+        assert_eq!(vertex_field.field, VertexField::Normal);
+
+        let vertex_field = &pipeline.vertex_fields[5];
+        assert_eq!(vertex_field.semantic_name, "tangent_in");
+        assert_eq!(vertex_field.field, VertexField::Tangent);
+
+        let vertex_field = &pipeline.vertex_fields[6];
+        assert_eq!(vertex_field.semantic_name, "mix_tex_coord_in");
+        assert_eq!(vertex_field.field, VertexField::MidTexCoord);
+
+        let vertex_field = &pipeline.vertex_fields[7];
+        assert_eq!(vertex_field.semantic_name, "virtual_texture_id_in");
+        assert_eq!(vertex_field.field, VertexField::VirtualTextureId);
+
+        let vertex_field = &pipeline.vertex_fields[8];
+        assert_eq!(vertex_field.semantic_name, "mc_entity_id_in");
+        assert_eq!(vertex_field.field, VertexField::McEntityId);
+
+        ///// ////////////////// /////
+        ///// gui.pipeline /////
+        ///// ////////////////// /////
+        let pipeline = &parsed.pipelines[2];
+        assert_eq!(pipeline.name, "gui");
+        assert_eq!(pipeline.pass, "Forward");
+        assert_eq!(pipeline.depth_func, CompareOp::LessEqual);
+
+        assert_eq!(pipeline.states.len(), 1);
+        assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
+
+        assert_eq!(pipeline.vertex_shader, ShaderSource::Path(String::from("shaders/gui")));
+        assert_eq!(
+            pipeline.fragment_shader,
+            Some(ShaderSource::Path(String::from("shaders/gui")))
+        );
+
+        assert_eq!(pipeline.vertex_fields.len(), 4);
+        let vertex_field = &pipeline.vertex_fields[0];
+        assert_eq!(vertex_field.semantic_name, "position_in");
+        assert_eq!(vertex_field.field, VertexField::Position);
+
+        let vertex_field = &pipeline.vertex_fields[1];
+        assert_eq!(vertex_field.semantic_name, "uv_in");
+        assert_eq!(vertex_field.field, VertexField::UV0);
+
+        let vertex_field = &pipeline.vertex_fields[2];
+        assert_eq!(vertex_field.semantic_name, "color_in");
+        assert_eq!(vertex_field.field, VertexField::Color);
+
+        let vertex_field = &pipeline.vertex_fields[3];
+        assert_eq!(vertex_field.semantic_name, "virtual_texture_id_in");
+        assert_eq!(vertex_field.field, VertexField::VirtualTextureId);
+    }
 
     Ok(())
 }

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -237,8 +237,16 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthWrite), true);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthTest), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/textured_unlit.vert");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/image_passthrough.frag");
+        check_shader(
+            shader_list,
+            &pipeline.vertex_shader,
+            path!("shaders" | "textured_unlit.vert"),
+        );
+        check_shader_option(
+            shader_list,
+            &pipeline.fragment_shader,
+            path!("shaders" | "image_passthrough.frag"),
+        );
 
         assert_eq!(pipeline.vertex_fields.len(), 2);
         let vertex_field = &pipeline.vertex_fields[0];
@@ -259,8 +267,16 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.len(), 1);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gbuffers_terrain.vert");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gbuffers_terrain.frag");
+        check_shader(
+            shader_list,
+            &pipeline.vertex_shader,
+            path!("shaders" | "gbuffers_terrain.vert"),
+        );
+        check_shader_option(
+            shader_list,
+            &pipeline.fragment_shader,
+            path!("shaders" | "gbuffers_terrain.frag"),
+        );
 
         assert_eq!(pipeline.vertex_fields.len(), 9);
         let vertex_field = &pipeline.vertex_fields[0];
@@ -310,8 +326,8 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.len(), 1);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gui.vert");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gui.frag");
+        check_shader(shader_list, &pipeline.vertex_shader, path!("shaders" | "gui.vert"));
+        check_shader_option(shader_list, &pipeline.fragment_shader, path!("shaders" | "gui.frag"));
 
         assert_eq!(pipeline.vertex_fields.len(), 4);
         let vertex_field = &pipeline.vertex_fields[0];

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -113,6 +113,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         let pass = &material.passes[0];
         assert_eq!(pass.name, "main");
         assert_eq!(pass.pipeline, "Final");
+        assert_eq!(pass.material_name, material.name);
 
         assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
         let binding = &pass.bindings["per_model_uniforms"];
@@ -129,6 +130,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         let pass = &material.passes[0];
         assert_eq!(pass.name, "main");
         assert_eq!(pass.pipeline, "gbuffers_terrain");
+        assert_eq!(pass.material_name, material.name);
 
         assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
         let binding = &pass.bindings["per_model_uniforms"];
@@ -145,6 +147,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         let pass = &material.passes[0];
         assert_eq!(pass.name, "main");
         assert_eq!(pass.pipeline, "gui");
+        assert_eq!(pass.material_name, material.name);
 
         assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
         let binding = &pass.bindings["per_model_uniforms"];
@@ -161,6 +164,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         let pass = &material.passes[0];
         assert_eq!(pass.name, "main");
         assert_eq!(pass.pipeline, "gui");
+        assert_eq!(pass.material_name, material.name);
 
         assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
         let binding = &pass.bindings["per_model_uniforms"];
@@ -177,6 +181,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         let pass = &material.passes[0];
         assert_eq!(pass.name, "main");
         assert_eq!(pass.pipeline, "gui");
+        assert_eq!(pass.material_name, material.name);
 
         assert_eq!(pass.bindings.contains_key("per_model_uniforms"), true);
         let binding = &pass.bindings["per_model_uniforms"];

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -5,10 +5,12 @@ use futures::executor::ThreadPoolBuilder;
 use nova_rs::shaderpack::*;
 use path_dsl::{path, PathDSL};
 
+/// Utility function that extracts the option, expecting it to be Some
 fn check_shader_option(shaders: &[LoadedShader], shader: &Option<ShaderSource>, filename: PathDSL) {
     check_shader(shaders, shader.as_ref().expect("Expected shader to exist"), filename);
 }
 
+/// Checks a shader is in the proper state, has the proper name, and an entry in the shader list
 fn check_shader(shaders: &[LoadedShader], shader: &ShaderSource, filename: PathDSL) {
     if let ShaderSource::Loaded(idx) = shader {
         let idx = *idx as usize;

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -3,7 +3,7 @@
 
 use futures::executor::ThreadPoolBuilder;
 use nova_rs::shaderpack::*;
-use std::path::PathBuf;
+use path_dsl::path;
 
 fn check_shader_option(shaders: &[LoadedShader], shader: &Option<ShaderSource>, filename: &str) {
     check_shader(shaders, shader.as_ref().expect("Expected shader to exist"), filename);
@@ -16,7 +16,7 @@ fn check_shader(shaders: &[LoadedShader], shader: &ShaderSource, filename: &str)
         let loaded = &shaders[idx];
         assert_eq!(loaded.filename.to_str(), Some(filename));
     } else {
-        panic!("ShaderSource not loaded.");
+        //        panic!("ShaderSource not loaded.");
     }
 }
 
@@ -30,7 +30,7 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
 
     let mut parsed: ShaderpackData = threadpool.run(load_nova_shaderpack(
         threadpool2,
-        PathBuf::from("tests/data/shaderpacks/nova/DefaultShaderpack"),
+        path!("tests" | "data" | "shaderpacks" | "nova" | "DefaultShaderpack").into(),
     ))?;
 
     // Shader Extraction

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -3,18 +3,18 @@
 
 use futures::executor::ThreadPoolBuilder;
 use nova_rs::shaderpack::*;
-use path_dsl::path;
+use path_dsl::{path, PathDSL};
 
-fn check_shader_option(shaders: &[LoadedShader], shader: &Option<ShaderSource>, filename: &str) {
+fn check_shader_option(shaders: &[LoadedShader], shader: &Option<ShaderSource>, filename: PathDSL) {
     check_shader(shaders, shader.as_ref().expect("Expected shader to exist"), filename);
 }
 
-fn check_shader(shaders: &[LoadedShader], shader: &ShaderSource, filename: &str) {
+fn check_shader(shaders: &[LoadedShader], shader: &ShaderSource, filename: PathDSL) {
     if let ShaderSource::Loaded(idx) = shader {
         let idx = *idx as usize;
         assert_eq!(idx < shaders.len(), true);
         let loaded = &shaders[idx];
-        assert_eq!(loaded.filename.to_str(), Some(filename));
+        assert_eq!(loaded.filename.to_str(), filename.to_str());
     } else {
         panic!("ShaderSource not loaded.");
     }

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -1,12 +1,19 @@
-use futures::executor::block_on;
+use futures::executor::{block_on, ThreadPoolBuilder};
 use nova_rs::shaderpack::*;
 use std::path::PathBuf;
 
 #[test]
 fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
-    let mut parsed: ShaderpackData = block_on(load_nova_shaderpack(PathBuf::from(
-        "tests/data/shaderpacks/nova/DefaultShaderpack",
-    )))?;
+    let mut threadpool = ThreadPoolBuilder::new()
+        .name_prefix("default_nova_shaderpack")
+        .create()
+        .unwrap();
+    let threadpool2 = threadpool.clone();
+
+    let mut parsed: ShaderpackData = threadpool.run(load_nova_shaderpack(
+        threadpool2,
+        PathBuf::from("tests/data/shaderpacks/nova/DefaultShaderpack"),
+    ))?;
 
     // Renderpass checking
     {

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -16,7 +16,7 @@ fn check_shader(shaders: &[LoadedShader], shader: &ShaderSource, filename: &str)
         let loaded = &shaders[idx];
         assert_eq!(loaded.filename.to_str(), Some(filename));
     } else {
-        //        panic!("ShaderSource not loaded.");
+        panic!("ShaderSource not loaded.");
     }
 }
 
@@ -237,8 +237,8 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthWrite), true);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableDepthTest), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/textured_unlit");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/image_passthrough");
+        check_shader(shader_list, &pipeline.vertex_shader, "shaders/textured_unlit.vert");
+        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/image_passthrough.frag");
 
         assert_eq!(pipeline.vertex_fields.len(), 2);
         let vertex_field = &pipeline.vertex_fields[0];
@@ -259,8 +259,8 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.len(), 1);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gbuffers_terrain");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gbuffers_terrain");
+        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gbuffers_terrain.vert");
+        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gbuffers_terrain.frag");
 
         assert_eq!(pipeline.vertex_fields.len(), 9);
         let vertex_field = &pipeline.vertex_fields[0];
@@ -310,8 +310,8 @@ fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
         assert_eq!(pipeline.states.len(), 1);
         assert_eq!(pipeline.states.contains(&RasterizerState::DisableAlphaWrite), true);
 
-        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gui");
-        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gui");
+        check_shader(shader_list, &pipeline.vertex_shader, "shaders/gui.vert");
+        check_shader_option(shader_list, &pipeline.fragment_shader, "shaders/gui.frag");
 
         assert_eq!(pipeline.vertex_fields.len(), 4);
         let vertex_field = &pipeline.vertex_fields[0];

--- a/tests/shaderpack_loading.rs
+++ b/tests/shaderpack_loading.rs
@@ -1,0 +1,13 @@
+use futures::executor::block_on;
+use nova_rs::shaderpack;
+use nova_rs::shaderpack::{load_nova_shaderpack, ShaderpackLoadingFailure};
+use std::path::PathBuf;
+
+#[test]
+fn default_nova_shaderpack() -> Result<(), ShaderpackLoadingFailure> {
+    let parsed = block_on(load_nova_shaderpack(PathBuf::from(
+        "tests/data/shaderpacks/nova/DefaultShaderpack",
+    )))?;
+
+    Ok(())
+}


### PR DESCRIPTION
This exists as both an proof of concept of the "everything is async" methodology, as well as a proper shaderpack loader. I have added comments to the async parts of the code as best I can. Please ask any questions you have.

Notable changes:
- Changed the file tree api multiple times because of lifespan issues.
- Load shaders once in a shaderpack local buffer, then associate the pipeline's shader references with an index into that buffer. This makes shader operations _much_ easier.
- Updated dependencies due to `cargo audit` catching a CVE

Closes #36 